### PR TITLE
Define Error.Code as authoritative

### DIFF
--- a/api.json
+++ b/api.json
@@ -1722,7 +1722,7 @@
         }
       },
      "Error": {
-       "description":"Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object.",
+       "description":"Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields.",
        "type":"object",
        "required": [
          "code",
@@ -1738,7 +1738,7 @@
            "example": 12
           },
          "message": {
-           "description":"Message is a network-specific error message.",
+           "description":"Message is a network-specific error message. The message MUST NOT change for a given code. In particular, this means that any contextual information should be included in the details field.",
            "type":"string",
            "example":"Invalid account format"
           },

--- a/models/Error.yaml
+++ b/models/Error.yaml
@@ -15,6 +15,10 @@
 description: |
   Instead of utilizing HTTP status codes to describe node errors (which often
   do not have a good analog), rich errors are returned using this object.
+
+  Both the code and message fields can be individually used to correctly
+  identify an error. Implementations MUST use unique values for both
+  fields.
 type: object
 required:
   - code
@@ -32,6 +36,10 @@ properties:
   message:
     description: |
       Message is a network-specific error message.
+
+      The message MUST NOT change for a given code. In particular, this
+      means that any contextual information should be included in
+      the details field.
     type: string
     example: "Invalid account format"
   retriable:


### PR DESCRIPTION
(Opening up as a PR directly with the suggested change to clarify this point for implementations and clients but happy to discuss if this isn't the actual intention of the Error Code/Message distinction.)

This makes it explicit that the Code attribute of the Error model is the
authoritative source of truth for the origin of the error, while the
error message is secondary.

It also makes it explicit that the same error code may present multiple
different messages so clients of Rosetta implementations should not rely
on them for error detection and Rosetta backends should make an effort
to present error codes in a granular enough level for clients.

