### PR TITLE
TransactionIdentifierResponse + change default status to 500

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.0",
+   "version":"1.4.1",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {
@@ -39,7 +39,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -81,7 +81,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -123,7 +123,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -165,7 +165,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -207,7 +207,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -249,7 +249,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -291,7 +291,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -333,7 +333,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -375,7 +375,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -417,7 +417,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -459,7 +459,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -501,7 +501,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -543,7 +543,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -585,7 +585,7 @@
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -622,12 +622,12 @@
            "content": {
              "application/json": {
                "schema": {
-                 "$ref":"#/components/schemas/ConstructionHashResponse"
+                 "$ref":"#/components/schemas/TransactionIdentifierResponse"
                 }
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -664,12 +664,12 @@
            "content": {
              "application/json": {
                "schema": {
-                 "$ref":"#/components/schemas/ConstructionSubmitResponse"
+                 "$ref":"#/components/schemas/TransactionIdentifierResponse"
                 }
               }
             }
           },
-         "default": {
+         "500": {
            "description":"unexpected error",
            "content": {
              "application/json": {
@@ -1678,18 +1678,6 @@
           }
         }
       },
-     "ConstructionHashResponse": {
-       "description":"ConstructionHashResponse is the output of the `/construction/hash` endpoint.",
-       "type":"object",
-       "required": [
-         "transaction_hash"
-        ],
-       "properties": {
-         "transaction_hash": {
-           "type":"string"
-          }
-        }
-      },
      "ConstructionSubmitRequest": {
        "description":"The transaction submission request includes a signed transaction.",
        "type":"object",
@@ -1706,8 +1694,8 @@
           }
         }
       },
-     "ConstructionSubmitResponse": {
-       "description":"A TransactionSubmitResponse contains the transaction_identifier of a submitted transaction that was accepted into the mempool.",
+     "TransactionIdentifierResponse": {
+       "description":"TransactionIdentifierResponse contains the transaction_identifier of a transaction that was submitted to either `/construction/hash` or `/construction/submit`.",
        "type":"object",
        "required": [
          "transaction_identifier"

--- a/api.yaml
+++ b/api.yaml
@@ -44,7 +44,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NetworkListResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -72,7 +72,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NetworkStatusResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -104,7 +104,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NetworkOptionsResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -143,7 +143,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BlockResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -189,7 +189,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BlockTransactionResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -215,7 +215,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MempoolResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -250,7 +250,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MempoolTransactionResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -293,7 +293,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AccountBalanceResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -323,7 +323,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstructionDeriveResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -356,7 +356,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstructionPreprocessResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -392,7 +392,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstructionMetadataResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -429,7 +429,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstructionPayloadsResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -460,7 +460,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstructionCombineResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -491,7 +491,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstructionParseResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -519,7 +519,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransactionIdentifierResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:
@@ -553,7 +553,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransactionIdentifierResponse'
-        default:
+        '500':
           description: unexpected error
           content:
             application/json:

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.0
+  version: 1.4.1
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.
@@ -518,7 +518,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConstructionHashResponse'
+                $ref: '#/components/schemas/TransactionIdentifierResponse'
         default:
           description: unexpected error
           content:
@@ -552,7 +552,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConstructionSubmitResponse'
+                $ref: '#/components/schemas/TransactionIdentifierResponse'
         default:
           description: unexpected error
           content:
@@ -1054,15 +1054,6 @@ components:
           $ref: '#/components/schemas/NetworkIdentifier'
         signed_transaction:
           type: string
-    ConstructionHashResponse:
-      description: |
-        ConstructionHashResponse is the output of the `/construction/hash` endpoint.
-      type: object
-      required:
-        - transaction_hash
-      properties:
-        transaction_hash:
-          type: string
     ConstructionSubmitRequest:
       description: |
         The transaction submission request includes a signed transaction.
@@ -1075,10 +1066,11 @@ components:
           $ref: '#/components/schemas/NetworkIdentifier'
         signed_transaction:
           type: string
-    ConstructionSubmitResponse:
+    TransactionIdentifierResponse:
       description: |
-        A TransactionSubmitResponse contains the transaction_identifier of a
-        submitted transaction that was accepted into the mempool.
+        TransactionIdentifierResponse contains the transaction_identifier of a
+        transaction that was submitted to either `/construction/hash` or
+        `/construction/submit`.
       type: object
       required:
         - transaction_identifier


### PR DESCRIPTION
Related Issue: #28

### Changes
- [x] Update version to v1.4.1
- [x] Use `TransactionIdentifierResponse` for both `/construction/hash` and `/construction/submit` [BREAKING for `/construction/hash` because of a mistake in v1.4.0]
- [x] Use `500` as response status instead of `default` (this is already specified in the docs: https://www.rosetta-api.org/docs/BlockApi.html#500---error-1)