### PR TITLE
Improved Fee Handling

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.1",
+   "version":"1.4.2",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {
@@ -1549,7 +1549,7 @@
         }
       },
      "ConstructionMetadataResponse": {
-       "description":"The ConstructionMetadataResponse returns network-specific metadata used for transaction construction.",
+       "description":"The ConstructionMetadataResponse returns network-specific metadata used for transaction construction. Optionally, the implementer can return the suggested fee associated with the transaction being constructed. The caller may use this info to adjust the intent of the transaction or to create a transaction with a different account that can pay the suggested fee. Suggested fee is an array in case fee payment must occur in multiple currencies.",
        "type":"object",
        "required": [
          "metadata"
@@ -1560,6 +1560,12 @@
            "example": {
              "account_sequence": 23,
              "recent_block_hash":"0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5"
+            }
+          },
+         "suggested_fee": {
+           "type":"array",
+           "items": {
+             "$ref":"#/components/schemas/Amount"
             }
           }
         }
@@ -1600,7 +1606,7 @@
         }
       },
      "ConstructionPreprocessRequest": {
-       "description":"ConstructionPreprocessRequest is passed to the `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata it needs to request for construction.",
+       "description":"ConstructionPreprocessRequest is passed to the `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata it needs to request for construction. The caller can provide a max fee they are willing to pay for a transaction. This is an array in the case fees must be paid in multiple currencies. The caller can also provide a suggested fee multiplier to indicate that the suggested fee should be scaled. This may be used to set higher fees for urgent transactions or to pay lower fees when there is less urgency. It is assumed that providing a very low multiplier (like 0.0001) will never lead to a transaction being created with a fee less than the minimum network fee (if applicable). In the case that the caller provides both a max fee and a suggested fee multiplier, the max fee will set an upper bound on the suggested fee (regardless of the multiplier provided).",
        "type":"object",
        "required": [
          "network_identifier",
@@ -1618,6 +1624,16 @@
           },
          "metadata": {
            "type":"object"
+          },
+         "max_fee": {
+           "type":"array",
+           "items": {
+             "$ref":"#/components/schemas/Amount"
+            }
+          },
+         "suggested_fee_multiplier": {
+           "type":"double",
+           "minimum": 0
           }
         }
       },

--- a/api.json
+++ b/api.json
@@ -1632,7 +1632,8 @@
             }
           },
          "suggested_fee_multiplier": {
-           "type":"double",
+           "type":"number",
+           "format":"double",
            "minimum": 0
           }
         }

--- a/api.yaml
+++ b/api.yaml
@@ -978,7 +978,8 @@ components:
           items:
             $ref: '#/components/schemas/Amount'
         suggested_fee_multiplier:
-          type: double
+          type: number
+          format: double
           minimum: 0.0
     ConstructionPreprocessResponse:
       description: |

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.1
+  version: 1.4.2
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.

--- a/api.yaml
+++ b/api.yaml
@@ -943,6 +943,23 @@ components:
         ConstructionPreprocessRequest is passed to the `/construction/preprocess`
         endpoint so that a Rosetta implementation can determine which
         metadata it needs to request for construction.
+
+        The caller can provide a max fee they are willing
+        to pay for a transaction. This is an array in the case fees
+        must be paid in multiple currencies.
+
+        The caller can also provide a suggested fee multiplier
+        to indicate that the suggested fee should be scaled.
+        This may be used to set higher fees for urgent transactions
+        or to pay lower fees when there is less urgency. It is assumed
+        that providing a very low multiplier (like 0.0001) will
+        never lead to a transaction being created with a fee
+        less than the minimum network fee (if applicable).
+
+        In the case that the caller provides both a max fee
+        and a suggested fee multiplier, the max fee will set an
+        upper bound on the suggested fee (regardless of the
+        multiplier provided).
       type: object
       required:
         - network_identifier
@@ -956,6 +973,13 @@ components:
             $ref: '#/components/schemas/Operation'
         metadata:
           type: object
+        max_fee:
+          type: array
+          items:
+            $ref: '#/components/schemas/Amount'
+        suggested_fee_multiplier:
+          type: double
+          minimum: 0.0
     ConstructionPreprocessResponse:
       description: |
         ConstructionPreprocessResponse contains the request that will

--- a/api.yaml
+++ b/api.yaml
@@ -886,6 +886,12 @@ components:
       description: |
         The ConstructionMetadataResponse returns network-specific metadata
         used for transaction construction.
+
+        Optionally, the implementer can return the suggested fee associated
+        with the transaction being constructed. The caller may use this info
+        to adjust the intent of the transaction or to create a transaction with
+        a different account that can pay the suggested fee. Suggested fee is an array
+        in case fee payment must occur in multiple currencies.
       type: object
       required:
         - metadata
@@ -895,6 +901,10 @@ components:
           example:
             account_sequence: 23
             recent_block_hash: "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5"
+        suggested_fee:
+          type: array
+          items:
+            $ref: '#/components/schemas/Amount'
     ConstructionDeriveRequest:
       description: |
         ConstructionDeriveRequest is passed to the `/construction/derive`


### PR DESCRIPTION
The Rosetta API does not support dynamic fees very well. This PR adds support for specifying fee and viewing the suggested fee (according to provided intent and network conditions).

### Changes
- [x] Specify `max_fee` in `/construction/preprocess`
- [x] Specify `suggested_fee_multiplier` in `/construction/preprocess`
- [x] Allow `suggested_fee` to be returned in `/construction/metadata`