### PR TITLE
Add more details about Metadata population

### DIFF
--- a/api.json
+++ b/api.json
@@ -391,7 +391,7 @@
    "/construction/preprocess": {
      "post": {
        "summary":"Create a Request to Fetch Metadata",
-       "description":"Preprocess is called prior to `/construction/payloads` to construct a request for any metadata that is needed for transaction construction given (i.e. account nonce). The request returned from this method will be used by the caller (in a different execution environment) to call the `/construction/metadata` endpoint.",
+       "description":"Preprocess is called prior to `/construction/payloads` to construct a request for any metadata that is needed for transaction construction given (i.e. account nonce). The `options` object returned from this endpoint will be sent to the `/construction/metadata` endpoint UNMODIFIED by the caller (in an offline execution environment). If your Construction API implementation has configuration options, they MUST be specified in the `/construction/preprocess` request (in the `metadata` field).",
        "operationId":"constructionPreprocess",
        "tags": [
          "Construction"
@@ -433,7 +433,7 @@
    "/construction/metadata": {
      "post": {
        "summary":"Get Metadata for Transaction Construction",
-       "description":"Get any information required to construct a transaction for a specific network. Metadata returned here could be a recent hash to use, an account sequence number, or even arbitrary chain state. The request used when calling this endpoint is often created by calling `/construction/preprocess` in an offline environment. It is important to clarify that this endpoint should not pre-construct any transactions for the client (this should happen in `/construction/payloads`). This endpoint is left purposely unstructured because of the wide scope of metadata that could be required.",
+       "description":"Get any information required to construct a transaction for a specific network. Metadata returned here could be a recent hash to use, an account sequence number, or even arbitrary chain state. The request used when calling this endpoint is created by calling `/construction/preprocess` in an offline environment. You should NEVER assume that the request sent to this endpoint will be created by the caller or populated with any custom parameters. This must occur in `/construction/preprocess`. It is important to clarify that this endpoint should not pre-construct any transactions for the client (this should happen in `/construction/payloads`). This endpoint is left purposely unstructured because of the wide scope of metadata that could be required.",
        "operationId":"constructionMetadata",
        "tags": [
          "Construction"
@@ -1606,7 +1606,7 @@
         }
       },
      "ConstructionPreprocessRequest": {
-       "description":"ConstructionPreprocessRequest is passed to the `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata it needs to request for construction. The caller can provide a max fee they are willing to pay for a transaction. This is an array in the case fees must be paid in multiple currencies. The caller can also provide a suggested fee multiplier to indicate that the suggested fee should be scaled. This may be used to set higher fees for urgent transactions or to pay lower fees when there is less urgency. It is assumed that providing a very low multiplier (like 0.0001) will never lead to a transaction being created with a fee less than the minimum network fee (if applicable). In the case that the caller provides both a max fee and a suggested fee multiplier, the max fee will set an upper bound on the suggested fee (regardless of the multiplier provided).",
+       "description":"ConstructionPreprocessRequest is passed to the `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata it needs to request for construction. Metadata provided in this object should NEVER be a product of live data (i.e. the caller must follow some network-specific data fetching strategy outside of the Construction API to populate required Metadata). If live data is required for construction, it MUST be fetched in the call to `/construction/metadata`. The caller can provide a max fee they are willing to pay for a transaction. This is an array in the case fees must be paid in multiple currencies. The caller can also provide a suggested fee multiplier to indicate that the suggested fee should be scaled. This may be used to set higher fees for urgent transactions or to pay lower fees when there is less urgency. It is assumed that providing a very low multiplier (like 0.0001) will never lead to a transaction being created with a fee less than the minimum network fee (if applicable). In the case that the caller provides both a max fee and a suggested fee multiplier, the max fee will set an upper bound on the suggested fee (regardless of the multiplier provided).",
        "type":"object",
        "required": [
          "network_identifier",

--- a/api.yaml
+++ b/api.yaml
@@ -340,12 +340,11 @@ paths:
         request for any metadata that is needed for transaction construction
         given (i.e. account nonce).
 
-        The request returned from this method will be used by the caller (in a
-        different execution environment) to call the `/construction/metadata`
-        endpoint.
-
-        This request will be sent UNMODIFIED to this endpoint. You
-        should not expect the caller to inspect or modify this request.
+        The `options` object returned from this endpoint will be sent to the `/construction/metadata`
+        endpoint UNMODIFIED by the caller (in an offline execution environment). If
+        your Construction API implementation has configuration options, they MUST
+        be specified in the `/construction/preprocess` request (in the `metadata`
+        field).
       operationId: constructionPreprocess
       tags:
         - Construction
@@ -952,8 +951,10 @@ components:
         metadata it needs to request for construction.
 
         Metadata provided in this object should NEVER be a product
-        of live data. Any live data MUST be fetched in a call
-        to `/construction/metadata`.
+        of live data (i.e. the caller must follow some network-specific
+        data fetching strategy outside of the Construction API to populate
+        required Metadata). If live data is required for construction, it MUST
+        be fetched in the call to `/construction/metadata`.
 
         The caller can provide a max fee they are willing
         to pay for a transaction. This is an array in the case fees

--- a/api.yaml
+++ b/api.yaml
@@ -343,6 +343,9 @@ paths:
         The request returned from this method will be used by the caller (in a
         different execution environment) to call the `/construction/metadata`
         endpoint.
+
+        This request will be sent UNMODIFIED to this endpoint. You
+        should not expect the caller to inspect or modify this request.
       operationId: constructionPreprocess
       tags:
         - Construction
@@ -372,8 +375,12 @@ paths:
         Get any information required to construct a transaction for a specific
         network. Metadata returned here could be a recent hash to use, an
         account sequence number, or even arbitrary chain state. The request
-        used when calling this endpoint is often created by calling
-        `/construction/preprocess` in an offline environment.
+        used when calling this endpoint is created by calling `/construction/preprocess`
+        in an offline environment.
+
+        You should NEVER assume that the request sent to this endpoint will be
+        created by the caller or populated with any custom parameters. This must
+        occur in `/construction/preprocess`.
 
         It is important to clarify that this endpoint should not pre-construct
         any transactions for the client (this should happen in `/construction/payloads`).
@@ -943,6 +950,10 @@ components:
         ConstructionPreprocessRequest is passed to the `/construction/preprocess`
         endpoint so that a Rosetta implementation can determine which
         metadata it needs to request for construction.
+
+        Metadata provided in this object should NEVER be a product
+        of live data. Any live data MUST be fetched in a call
+        to `/construction/metadata`.
 
         The caller can provide a max fee they are willing
         to pay for a transaction. This is an array in the case fees


### PR DESCRIPTION
This PR adds additional documentation around how network-specific `Metadata` should be provided to the `Construction API`.  Many of the additional details here were provided in response to discussions on the community: https://community.rosetta-api.org/t/rosetta-cli-check-construction-dynamic-parameter/145?u=patrick.ogrady