### PR TITLE
Support Omitted Blocks

### DIFF
--- a/api.json
+++ b/api.json
@@ -1346,11 +1346,15 @@
        "description":"A BlockResponse includes a fully-populated block or a partially-populated block with a list of other transactions to fetch (other_transactions).",
        "type":"object",
        "required": [
-         "block"
+         "block_omitted"
         ],
        "properties": {
          "block": {
            "$ref":"#/components/schemas/Block"
+          },
+         "block_omitted": {
+           "description":"As a result of the consensus algorithm of some blockchains, blocks can be omitted (i.e. certain block indexes can be skipped). If a query for one of these omitted indexes is made, the response should return `true` for this field. It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block.",
+           "type":"boolean"
           },
          "other_transactions": {
            "description":"Some blockchains may require additional transactions to be fetched that weren't returned in the block response (ex: block only returns transaction hashes). For blockchains with a lot of transactions in each block, this can be very useful as consumers can concurrently fetch all transactions returned.",

--- a/api.json
+++ b/api.json
@@ -1343,18 +1343,11 @@
         }
       },
      "BlockResponse": {
-       "description":"A BlockResponse includes a fully-populated block or a partially-populated block with a list of other transactions to fetch (other_transactions).",
+       "description":"A BlockResponse includes a fully-populated block or a partially-populated block with a list of other transactions to fetch (other_transactions). As a result of the consensus algorithm of some blockchains, blocks can be omitted (i.e. certain block indexes can be skipped). If a query for one of these omitted indexes is made, the response should not include a `Block` object. It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block.",
        "type":"object",
-       "required": [
-         "block_omitted"
-        ],
        "properties": {
          "block": {
            "$ref":"#/components/schemas/Block"
-          },
-         "block_omitted": {
-           "description":"As a result of the consensus algorithm of some blockchains, blocks can be omitted (i.e. certain block indexes can be skipped). If a query for one of these omitted indexes is made, the response should return `true` for this field. It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block.",
-           "type":"boolean"
           },
          "other_transactions": {
            "description":"Some blockchains may require additional transactions to be fetched that weren't returned in the block response (ex: block only returns transaction hashes). For blockchains with a lot of transactions in each block, this can be very useful as consumers can concurrently fetch all transactions returned.",

--- a/api.yaml
+++ b/api.yaml
@@ -702,10 +702,22 @@ components:
         block with a list of other transactions to fetch (other_transactions).
       type: object
       required:
-        - block
+        - block_omitted
       properties:
         block:
           $ref: '#/components/schemas/Block'
+        block_omitted:
+          description: |
+            As a result of the consensus algorithm of some blockchains, blocks
+            can be omitted (i.e. certain block indexes can be skipped). If a query
+            for one of these omitted indexes is made, the response should return
+            `true` for this field.
+
+            It is VERY important to note that blocks MUST still form a canonical,
+            connected chain of blocks where each block has a unique index. In other words,
+            the `PartialBlockIdentifier` of a block after an omitted block should
+            reference the last non-omitted block.
+          type: boolean
         other_transactions:
           description: |
             Some blockchains may require additional transactions to be fetched

--- a/api.yaml
+++ b/api.yaml
@@ -700,24 +700,20 @@ components:
       description: |
         A BlockResponse includes a fully-populated block or a partially-populated
         block with a list of other transactions to fetch (other_transactions).
+
+        As a result of the consensus algorithm of some blockchains, blocks
+        can be omitted (i.e. certain block indexes can be skipped). If a query
+        for one of these omitted indexes is made, the response should not include
+        a `Block` object.
+
+        It is VERY important to note that blocks MUST still form a canonical,
+        connected chain of blocks where each block has a unique index. In other words,
+        the `PartialBlockIdentifier` of a block after an omitted block should
+        reference the last non-omitted block.
       type: object
-      required:
-        - block_omitted
       properties:
         block:
           $ref: '#/components/schemas/Block'
-        block_omitted:
-          description: |
-            As a result of the consensus algorithm of some blockchains, blocks
-            can be omitted (i.e. certain block indexes can be skipped). If a query
-            for one of these omitted indexes is made, the response should return
-            `true` for this field.
-
-            It is VERY important to note that blocks MUST still form a canonical,
-            connected chain of blocks where each block has a unique index. In other words,
-            the `PartialBlockIdentifier` of a block after an omitted block should
-            reference the last non-omitted block.
-          type: boolean
         other_transactions:
           description: |
             Some blockchains may require additional transactions to be fetched


### PR DESCRIPTION
In some blockchains, blocks may be "omitted" at certain indexes (i.e. skipped). In this case, the `BlockResponse.Block` should be left unpopulated.

It is VERY important to note that blocks MUST still form a canonical, connected chain of blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a block after an omitted block should reference the last non-omitted block.

Related Post: https://community.rosetta-api.org/t/what-rosetta-expects-as-block-response-when-a-block-was-not-produced/156

Related PRs:
* https://github.com/coinbase/rosetta-sdk-go/pull/91
* https://github.com/coinbase/rosetta-cli/pull/98

### Changes
- [x] Make `BlockResponse.Block` not required