### PR TITLE
feat/add-ecschnorr-declaration

### DIFF
--- a/api.json
+++ b/api.json
@@ -1211,12 +1211,13 @@
         }
       },
      "SignatureType": {
-       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`",
+       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * ecschnorr: `R (64-bytes) || s (64-bytes)` - `128 bytes`",
        "type":"string",
        "enum": [
          "ecdsa",
          "ecdsa_recovery",
-         "ed25519"
+         "ed25519",
+         "ecschnorr"
         ]
       },
      "CoinAction": {

--- a/api.json
+++ b/api.json
@@ -1211,7 +1211,7 @@
         }
       },
      "SignatureType": {
-       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * ecschnorr: `R (64-bytes) || s (64-bytes)` - `128 bytes`",
+       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * ecschnorr: `r (32-bytes) || s (32-bytes)` - `64 bytes`",
        "type":"string",
        "enum": [
          "ecdsa",

--- a/models/SignatureType.yaml
+++ b/models/SignatureType.yaml
@@ -18,8 +18,10 @@ description: |
   * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes`
   * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes`
   * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
+  * ecschnorr: `R (64-bytes) || s (64-bytes)` - `128 bytes`
 type: string
 enum:
   - ecdsa
   - ecdsa_recovery
   - ed25519
+  - ecschnorr

--- a/models/SignatureType.yaml
+++ b/models/SignatureType.yaml
@@ -18,7 +18,7 @@ description: |
   * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes`
   * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes`
   * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
-  * ecschnorr: `R (64-bytes) || s (64-bytes)` - `128 bytes`
+  * ecschnorr: `r (32-bytes) || s (32-bytes)` - `64 bytes`
 type: string
 enum:
   - ecdsa


### PR DESCRIPTION
This pr adds the support for Ec-Schnorr signature type.

I am a developer from Zilliqa; working on a rosetta sdk implementation for our side. As our blockchain employs a `secp256k1` Curve with a `schnorr` Signature Type, we hope to include this signature and subsequently the signer and verify support into `rosetta-sdk-go`.

Zilliqa Schnorr Signature: https://dev.zilliqa.com/docs/basics/basics-zil-schnorr-signatures/
Contact: teye@zilliqa.com