### PR TITLE
Fix RelatedOperations example

### DIFF
--- a/api.json
+++ b/api.json
@@ -787,7 +787,7 @@
            "type":"integer",
            "format":"int64",
            "minimum": 0,
-           "example": 1
+           "example": 5
           },
          "network_index": {
            "description":"Some blockchains specify an operation index that is essential for client use. For example, Bitcoin uses a network_index to identify which UTXO was used in a transaction. network_index should not be populated if there is no notion of an operation index in a blockchain (typically most account-based blockchains).",
@@ -918,10 +918,10 @@
             },
            "example": [
               {
-               "index": 0,
-               "operation_identifier": {
-                 "index": 0
-                }
+               "index": 1
+              },
+              {
+               "index": 2
               }
             ]
           },

--- a/models/Operation.yaml
+++ b/models/Operation.yaml
@@ -36,9 +36,8 @@ properties:
     items:
       $ref: 'OperationIdentifier.yaml'
     example:
-      - index: 0
-        operation_identifier:
-          index: 0
+      - index: 1
+      - index: 2
   type:
     description: |
       The network-specific type of the operation. Ensure that any type that can be returned here is also

--- a/models/OperationIdentifier.yaml
+++ b/models/OperationIdentifier.yaml
@@ -28,7 +28,7 @@ properties:
     type: integer
     format: int64
     minimum: 0
-    example: 1
+    example: 5
   network_index:
     description: |
       Some blockchains specify an operation index that is essential for client use. For example,


### PR DESCRIPTION
Credit to @metajack for finding this one!

The `Operation.RelatedOperations` example was completely wrong. This made the `Operation` example particularly hard to understand (it looked like there was an extra index in there somehow)!

#### Broken
![image](https://user-images.githubusercontent.com/13023275/90086486-5d4eae80-dccf-11ea-911d-4752950290b5.png)

#### Fix
![image](https://user-images.githubusercontent.com/13023275/90086677-d2ba7f00-dccf-11ea-954d-17fb3ed2d3bd.png)

### Changes
- [X] Fix the example!