### PR TITLE
feat/add-ecschnorr-support-for-zilliqa

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Construction API implementation.
 * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
 * schnorr_1: `r (32-bytes) || s (32-bytes)` - `64 bytes`
 
-`schnorr_1` is a EC-Schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first. Refer to [Zilliqa Technical Whitepaper - Appendix A: Schnorr Digital Signature](https://docs.zilliqa.com/whitepaper.pdf) for details.)
+`schnorr_1` is a EC-Schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first. Refer to [Zilliqa's Schnorr Library](https://github.com/Zilliqa/schnorr/blob/master/src/libSchnorr/src/Schnorr.cpp#L86) and [Zilliqa Technical Whitepaper - Appendix A: Schnorr Digital Signature](https://docs.zilliqa.com/whitepaper.pdf) for details.)
 
 ### Decoupled Signature Schemes
 CurveType and SignatureType are purposely decoupled as a curve could be used

--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ Construction API implementation.
 * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes`
 * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes`
 * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
+* schnorr_1: `r (32-bytes) || s (32-bytes)` - `64 bytes`
+
+`schnorr_1` is a EC-Schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first. Refer to [Zilliqa Technical Whitepaper - Appendix A: Schnorr Digital Signature](https://docs.zilliqa.com/whitepaper.pdf) for details.)
 
 ### Decoupled Signature Schemes
 CurveType and SignatureType are purposely decoupled as a curve could be used

--- a/api.json
+++ b/api.json
@@ -1211,13 +1211,13 @@
         }
       },
      "SignatureType": {
-       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * ecschnorr: `r (32-byte) || s (32-bytes)` - `64 bytes`",
+       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * schnorr_1: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first.)",
        "type":"string",
        "enum": [
          "ecdsa",
          "ecdsa_recovery",
          "ed25519",
-         "ecschnorr"
+         "schnorr_1"
         ]
       },
      "CoinAction": {

--- a/api.json
+++ b/api.json
@@ -1211,12 +1211,13 @@
         }
       },
      "SignatureType": {
-       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`",
+       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * ecschnorr: `r (32-byte) || s (32-bytes)` - `64 bytes`",
        "type":"string",
        "enum": [
          "ecdsa",
          "ecdsa_recovery",
-         "ed25519"
+         "ed25519",
+         "ecschnorr"
         ]
       },
      "CoinAction": {

--- a/models/SignatureType.yaml
+++ b/models/SignatureType.yaml
@@ -18,8 +18,10 @@ description: |
   * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes`
   * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes`
   * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
+  * ecschnorr: `r (32-byte) || s (32-bytes)` - `64 bytes`
 type: string
 enum:
   - ecdsa
   - ecdsa_recovery
   - ed25519
+  - ecschnorr

--- a/models/SignatureType.yaml
+++ b/models/SignatureType.yaml
@@ -18,10 +18,10 @@ description: |
   * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes`
   * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes`
   * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
-  * ecschnorr: `r (32-byte) || s (32-bytes)` - `64 bytes`
+  * schnorr_1: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first.)
 type: string
 enum:
   - ecdsa
   - ecdsa_recovery
   - ed25519
-  - ecschnorr
+  - schnorr_1


### PR DESCRIPTION
### Introduction

This pr adds the support for Zilliqa's Ec-Schnorr signature type.

I am a developer from Zilliqa; working on a rosetta sdk implementation for our side. As our blockchain employs a secp256k1 Curve with a schnorr Signature Type, we hope to include this signature and subsequently the signer and verifier support into rosetta-sdk-go.

### How does the Zilliqa schnorr signature encoding format differ from the one proposed in [BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)?

1. BIP-0340 generates a signature of constant size 64 bytes `(r||s)` , where `r` is the X-coordinate of a point on the curve encoded as a 32-bytes value, most significant byte first. `s` is a scalar encoded as a 32-bytes value, most significant byte first.
2. ZIL-Schnorr generates a signature of constant size 64 bytes `(r||s)` , where both `r` and `s` are scalars encoded as 32-bytes values, most significant byte first.
3. Public key as used in BIP-0340, is a point on the curve represented only using its X-coordinate. The public key’s Y-coordinate must be even. Public key used in ZIL-Schnorr is a point on the curve represented in the compressed format that requires 33 bytes (the first byte is a sign byte, `0x02` or `0x03`) while the remaining 32 bytes represent the X-coordinate of the point. 

### Reference
Zilliqa Schnorr Signature: https://dev.zilliqa.com/docs/basics/basics-zil-schnorr-signatures/
Technical Whitepaper: https://docs.zilliqa.com/whitepaper.pdf

### Contact
teye@zilliqa.com