### PR TITLE
fix: fixed Signers description to explicitly mention addresses are required

### DIFF
--- a/api.json
+++ b/api.json
@@ -1744,7 +1744,7 @@
             }
           },
          "signers": {
-           "description":"All signers of a particular transaction. If the transaction is unsigned, it should be empty.",
+           "description":"All signers (addresses) of a particular transaction. If the transaction is unsigned, it should be empty.",
            "type":"array",
            "items": {
              "type":"string"

--- a/api.yaml
+++ b/api.yaml
@@ -1063,7 +1063,7 @@ components:
             $ref: '#/components/schemas/Operation'
         signers:
           description: |
-            All signers of a particular transaction. If the transaction
+            All signers (addresses) of a particular transaction. If the transaction
             is unsigned, it should be empty.
           type: array
           items:


### PR DESCRIPTION
Fixes #40 

### Motivation

Improves the description otherwise it's extremely unlikely to guess

### Solution

n/a 

### Open questions

Should signers be derived from public keys?