### PR TITLE
Access PublicKeys During Construction

### DIFF
--- a/api.json
+++ b/api.json
@@ -1638,14 +1638,14 @@
         }
       },
      "ConstructionPreprocessResponse": {
-       "description":"ConstructionPreprocessResponse contains `options` that will be sent unmodified to `/construction/metadata`. If it is not necessary to make a request to `/construction/metadata`, `options` should be omitted.  Some blockchains require the PublicKey of particular AccountIdentifiers to construct a valid transaction. To fetch these PublicKeys, populate `public_keys` with the AccountIdentifiers associated with the desired PublicKeys. If it is not necessary to retrieve any PublicKeys for construction, `public_keys` should be omitted.",
+       "description":"ConstructionPreprocessResponse contains `options` that will be sent unmodified to `/construction/metadata`. If it is not necessary to make a request to `/construction/metadata`, `options` should be omitted.  Some blockchains require the PublicKey of particular AccountIdentifiers to construct a valid transaction. To fetch these PublicKeys, populate `required_public_keys` with the AccountIdentifiers associated with the desired PublicKeys. If it is not necessary to retrieve any PublicKeys for construction, `required_public_keys` should be omitted.",
        "type":"object",
        "properties": {
          "options": {
            "type":"object",
            "description":"The options that will be sent directly to `/construction/metadata` by the caller."
           },
-         "public_keys": {
+         "required_public_keys": {
            "type":"array",
            "items": {
              "$ref":"#/components/schemas/AccountIdentifier"

--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.2",
+   "version":"1.4.3",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {
@@ -1638,17 +1638,23 @@
         }
       },
      "ConstructionPreprocessResponse": {
-       "description":"ConstructionPreprocessResponse contains the request that will be sent directly to `/construction/metadata`. If it is not necessary to make a request to `/construction/metadata`, options should be null.",
+       "description":"ConstructionPreprocessResponse contains `options` that will be sent unmodified to `/construction/metadata`. If it is not necessary to make a request to `/construction/metadata`, `options` should be omitted.  Some blockchains require the PublicKey of particular AccountIdentifiers to construct a valid transaction. To fetch these PublicKeys, populate `public_keys` with the AccountIdentifiers associated with the desired PublicKeys. If it is not necessary to retrieve any PublicKeys for construction, `public_keys` should be omitted.",
        "type":"object",
        "properties": {
          "options": {
            "type":"object",
            "description":"The options that will be sent directly to `/construction/metadata` by the caller."
+          },
+         "public_keys": {
+           "type":"array",
+           "items": {
+             "$ref":"#/components/schemas/AccountIdentifier"
+            }
           }
         }
       },
      "ConstructionPayloadsRequest": {
-       "description":"ConstructionPayloadsRequest is the request to `/construction/payloads`. It contains the network, a slice of operations, and arbitrary metadata that was returned by the call to `/construction/metadata`.",
+       "description":"ConstructionPayloadsRequest is the request to `/construction/payloads`. It contains the network, a slice of operations, and arbitrary metadata that was returned by the call to `/construction/metadata`. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.",
        "type":"object",
        "required": [
          "network_identifier",
@@ -1666,6 +1672,12 @@
           },
          "metadata": {
            "type":"object"
+          },
+         "public_keys": {
+           "type":"array",
+           "items": {
+             "$ref":"#/components/schemas/PublicKey"
+            }
           }
         }
       },

--- a/api.yaml
+++ b/api.yaml
@@ -1010,9 +1010,9 @@ components:
 
         Some blockchains require the PublicKey of particular AccountIdentifiers
         to construct a valid transaction. To fetch these PublicKeys, populate
-        `public_keys` with the AccountIdentifiers associated with the desired
+        `required_public_keys` with the AccountIdentifiers associated with the desired
         PublicKeys. If it is not necessary to retrieve any PublicKeys
-        for construction, `public_keys` should be omitted.
+        for construction, `required_public_keys` should be omitted.
       type: object
       properties:
         options:
@@ -1020,7 +1020,7 @@ components:
           description: |
             The options that will be sent directly to `/construction/metadata` by
             the caller.
-        public_keys:
+        required_public_keys:
           type: array
           items:
             $ref: '#/components/schemas/AccountIdentifier'

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.2
+  version: 1.4.3
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.
@@ -1003,11 +1003,16 @@ components:
           minimum: 0.0
     ConstructionPreprocessResponse:
       description: |
-        ConstructionPreprocessResponse contains the request that will
-        be sent directly to `/construction/metadata`.
+        ConstructionPreprocessResponse contains `options` that will
+        be sent unmodified to `/construction/metadata`. If it is
+        not necessary to make a request to `/construction/metadata`,
+        `options` should be omitted. 
 
-        If it is not necessary to make a request to `/construction/metadata`,
-        options should be null.
+        Some blockchains require the PublicKey of particular AccountIdentifiers
+        to construct a valid transaction. To fetch these PublicKeys, populate
+        `public_keys` with the AccountIdentifiers associated with the desired
+        PublicKeys. If it is not necessary to retrieve any PublicKeys
+        for construction, `public_keys` should be omitted.
       type: object
       properties:
         options:
@@ -1015,12 +1020,20 @@ components:
           description: |
             The options that will be sent directly to `/construction/metadata` by
             the caller.
+        public_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountIdentifier'
     ConstructionPayloadsRequest:
       description: |
         ConstructionPayloadsRequest is the request to
         `/construction/payloads`. It contains the network,
         a slice of operations, and arbitrary metadata
         that was returned by the call to `/construction/metadata`.
+
+        Optionally, the request can also include an array
+        of PublicKeys associated with the AccountIdentifiers
+        returned in ConstructionPreprocessResponse.
       type: object
       required:
         - network_identifier
@@ -1034,6 +1047,10 @@ components:
             $ref: '#/components/schemas/Operation'
         metadata:
           type: object
+        public_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicKey'
     ConstructionPayloadsResponse:
       description: |
         ConstructionTransactionResponse is returned by `/construction/payloads`. It


### PR DESCRIPTION
Closes: #43 
Additional Context: https://community.rosetta-api.org/t/any-way-to-get-public-key-from-signer-package-before-combine/189

### Motivation
In some blockchains, transaction construction requires the `PublicKey` of some `AccountIdentifiers` present in a transaction.

### Changes
This PR allows a Rosetta implementation to request the `PublicKey` of any number of `AccountIdentifiers` in the `/construction/preprocess` response. The caller can then provide the requested `PublicKeys` in a call to `/construction/payloads` so that construction can be completed.