### PR TITLE
Provide PubKeys to /construction/metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Construction API implementation.
 
 ### Supported CurveTypes
 * secp256k1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3)
+* secp256r1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3)
 * edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf)
 
 ### Supported SignatureTypes

--- a/api.json
+++ b/api.json
@@ -1531,7 +1531,7 @@
         }
       },
      "ConstructionMetadataRequest": {
-       "description":"A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers.",
+       "description":"A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.",
        "type":"object",
        "required": [
          "network_identifier",
@@ -1544,6 +1544,12 @@
          "options": {
            "description":"Some blockchains require different metadata for different types of transaction construction (ex: delegation versus a transfer). Instead of requiring a blockchain node to return all possible types of metadata for construction (which may require multiple node fetches), the client can populate an options object to limit the metadata returned to only the subset required.",
            "type":"object"
+          },
+         "public_keys": {
+           "type":"array",
+           "items": {
+             "$ref":"#/components/schemas/PublicKey"
+            }
           }
         }
       },

--- a/api.yaml
+++ b/api.yaml
@@ -880,6 +880,10 @@ components:
         to construct a transaction. The Options object used to specify which
         metadata to return is left purposely unstructured to allow flexibility
         for implementers.
+
+        Optionally, the request can also include an array
+        of PublicKeys associated with the AccountIdentifiers
+        returned in ConstructionPreprocessResponse.
       type: object
       required:
         - network_identifier
@@ -896,6 +900,10 @@ components:
             the client can populate an options object to limit the metadata
             returned to only the subset required.
           type: object
+        public_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicKey'
     ConstructionMetadataResponse:
       description: |
         The ConstructionMetadataResponse returns network-specific metadata


### PR DESCRIPTION
Related PR: #45 

Some blockchains require the PublicKey to fetch metadata for transaction construction. This PR allows for passing the requested PublicKeys into `/construction/metadata`. 