### PR TITLE
Deprecate Address-based Fields

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.3",
+   "version":"1.4.4",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {
@@ -348,8 +348,8 @@
     },
    "/construction/derive": {
      "post": {
-       "summary":"Derive an Address from a PublicKey",
-       "description":"Derive returns the network-specific address associated with a public key. Blockchains that require an on-chain action to create an account should not implement this method.",
+       "summary":"Derive an AccountIdentifier from a PublicKey",
+       "description":"Derive returns the AccountIdentifier associated with a public key. Blockchains that require an on-chain action to create an account should not implement this method.",
        "operationId":"constructionDerive",
        "tags": [
          "Construction"
@@ -475,7 +475,7 @@
    "/construction/payloads": {
      "post": {
        "summary":"Generate an Unsigned Transaction and Signing Payloads",
-       "description":"Payloads is called with an array of operations and the response from `/construction/metadata`. It returns an unsigned transaction blob and a collection of payloads that must be signed by particular addresses using a certain SignatureType. The array of operations provided in transaction construction often times can not specify all \"effects\" of a transaction (consider invoked transactions in Ethereum). However, they can deterministically specify the \"intent\" of the transaction, which is sufficient for construction. For this reason, parsing the corresponding transaction in the Data API (when it lands on chain) will contain a superset of whatever operations were provided during construction.",
+       "description":"Payloads is called with an array of operations and the response from `/construction/metadata`. It returns an unsigned transaction blob and a collection of payloads that must be signed by particular AccountIdentifiers using a certain SignatureType. The array of operations provided in transaction construction often times can not specify all \"effects\" of a transaction (consider invoked transactions in Ethereum). However, they can deterministically specify the \"intent\" of the transaction, which is sufficient for construction. For this reason, parsing the corresponding transaction in the Data API (when it lands on chain) will contain a superset of whatever operations were provided during construction.",
        "operationId":"constructionPayloads",
        "tags": [
          "Construction"
@@ -1169,16 +1169,18 @@
         ]
       },
      "SigningPayload": {
-       "description":"SigningPayload is signed by the client with the keypair associated with an address using the specified SignatureType. SignatureType can be optionally populated if there is a restriction on the signature scheme that can be used to sign the payload.",
+       "description":"SigningPayload is signed by the client with the keypair associated with an AccountIdentifier using the specified SignatureType. SignatureType can be optionally populated if there is a restriction on the signature scheme that can be used to sign the payload.",
        "type":"object",
        "required": [
-         "address",
          "hex_bytes"
         ],
        "properties": {
          "address": {
            "type":"string",
-           "description":"The network-specific address of the account that should sign the payload."
+           "description":"[DEPRECATED by `account_identifier` in `v1.4.4`] The network-specific address of the account that should sign the payload."
+          },
+         "account_identifier": {
+           "$ref":"#/components/schemas/AccountIdentifier"
           },
          "hex_bytes": {
            "type":"string"
@@ -1599,13 +1601,13 @@
      "ConstructionDeriveResponse": {
        "description":"ConstructionDeriveResponse is returned by the `/construction/derive` endpoint.",
        "type":"object",
-       "required": [
-         "address"
-        ],
        "properties": {
          "address": {
            "type":"string",
-           "description":"Address in network-specific format."
+           "description":"[DEPRECATED by `account_identifier` in `v1.4.4`] Address in network-specific format."
+          },
+         "account_identifier": {
+           "$ref":"#/components/schemas/AccountIdentifier"
           },
          "metadata": {
            "type":"object"
@@ -1769,8 +1771,7 @@
        "description":"ConstructionParseResponse contains an array of operations that occur in a transaction blob. This should match the array of operations provided to `/construction/preprocess` and `/construction/payloads`.",
        "type":"object",
        "required": [
-         "operations",
-         "signers"
+         "operations"
         ],
        "properties": {
          "operations": {
@@ -1780,10 +1781,16 @@
             }
           },
          "signers": {
-           "description":"All signers (addresses) of a particular transaction. If the transaction is unsigned, it should be empty.",
+           "description":"[DEPRECATED by `account_identifier_signers` in `v1.4.4`] All signers (addresses) of a particular transaction. If the transaction is unsigned, it should be empty.",
            "type":"array",
            "items": {
              "type":"string"
+            }
+          },
+         "account_identifier_signers": {
+           "type":"array",
+           "items": {
+             "$ref":"#/components/schemas/AccountIdentifier"
             }
           },
          "metadata": {

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.3
+  version: 1.4.4
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.
@@ -304,9 +304,9 @@ paths:
                 $ref: '#/components/schemas/Error'
   /construction/derive:
     post:
-      summary: Derive an Address from a PublicKey
+      summary: Derive an AccountIdentifier from a PublicKey
       description: |
-        Derive returns the network-specific address associated with a public key.
+        Derive returns the AccountIdentifier associated with a public key.
 
         Blockchains that require an on-chain action to create an
         account should not implement this method.
@@ -414,7 +414,7 @@ paths:
         Payloads is called with an array of operations
         and the response from `/construction/metadata`. It returns an
         unsigned transaction blob and a collection of payloads that must
-        be signed by particular addresses using a certain SignatureType.
+        be signed by particular AccountIdentifiers using a certain SignatureType.
 
         The array of operations provided in transaction construction often times
         can not specify all "effects" of a transaction (consider invoked transactions
@@ -951,13 +951,13 @@ components:
         ConstructionDeriveResponse is returned by the `/construction/derive`
         endpoint.
       type: object
-      required:
-        - address
       properties:
         address:
           type: string
           description: |
-            Address in network-specific format.
+            [DEPRECATED by `account_identifier` in `v1.4.4`] Address in network-specific format.
+        account_identifier:
+          $ref: '#/components/schemas/AccountIdentifier'
         metadata:
           type: object
     ConstructionPreprocessRequest:
@@ -1138,7 +1138,6 @@ components:
       type: object
       required:
         - operations
-        - signers
       properties:
         operations:
           type: array
@@ -1146,11 +1145,15 @@ components:
             $ref: '#/components/schemas/Operation'
         signers:
           description: |
-            All signers (addresses) of a particular transaction. If the transaction
+            [DEPRECATED by `account_identifier_signers` in `v1.4.4`] All signers (addresses) of a particular transaction. If the transaction
             is unsigned, it should be empty.
           type: array
           items:
             type: string
+        account_identifier_signers:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountIdentifier'
         metadata:
           type: object
     ConstructionHashRequest:

--- a/models/SigningPayload.yaml
+++ b/models/SigningPayload.yaml
@@ -14,21 +14,22 @@
 
 description: |
   SigningPayload is signed by the client with the keypair associated
-  with an address using the specified SignatureType.
+  with an AccountIdentifier using the specified SignatureType.
 
   SignatureType can be optionally populated if there is
   a restriction on the signature scheme that can be
   used to sign the payload.
 type: object
 required:
-  - address
   - hex_bytes
 properties:
   address:
     type: string
     description: |
-      The network-specific address of the account that should sign
+      [DEPRECATED by `account_identifier` in `v1.4.4`] The network-specific address of the account that should sign
       the payload.
+  account_identifier:
+    $ref: 'AccountIdentifier.yaml'
   hex_bytes:
     type: string
   signature_type:


### PR DESCRIPTION
Closes #47 

This PR deprecates all string `Address` field and replaces them with `AccountIdentifier`. This PR **DOES NOT** break any existing implementations (who will just continue populating `Address-based` fields unless they need extra expressivity).

### Modified Models
- [x] `ConstructionDeriveResponse`
- [x] `ConstructionParseResponse`
- [x] `SigningPayload`