### PR TITLE
updated types field description in Operation

### DIFF
--- a/api.json
+++ b/api.json
@@ -926,7 +926,7 @@
             ]
           },
          "type": {
-           "description":"The network-specific type of the operation. Ensure that any type that can be returned here is also specified in the NetworkStatus. This can be very useful to downstream consumers that parse all block data.",
+           "description":"The network-specific type of the operation. Ensure that any type that can be returned here is also specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all block data.",
            "type":"string",
            "example":"Transfer"
           },

--- a/models/Operation.yaml
+++ b/models/Operation.yaml
@@ -41,7 +41,7 @@ properties:
   type:
     description: |
       The network-specific type of the operation. Ensure that any type that can be returned here is also
-      specified in the NetworkStatus. This can be very useful to downstream consumers that parse all
+      specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all
       block data.
     type: string
     example: "Transfer"


### PR DESCRIPTION
Fixes # .

### Motivation
Operation types are now specified in `NetworkOptionsResponse`, rather than `NetworkStatus`

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
