### PR TITLE
[Construction] Options Parity

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.4",
+   "version":"1.4.5",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {
@@ -1535,11 +1535,10 @@
         }
       },
      "ConstructionMetadataRequest": {
-       "description":"A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.",
+       "description":"A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers. Options is not required in the case that there is network-wide metadata of interest. Optionally, the request can also include an array of PublicKeys associated with the AccountIdentifiers returned in ConstructionPreprocessResponse.",
        "type":"object",
        "required": [
-         "network_identifier",
-         "options"
+         "network_identifier"
         ],
        "properties": {
          "network_identifier": {

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.4
+  version: 1.4.5
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.
@@ -877,9 +877,12 @@ components:
     ConstructionMetadataRequest:
       description: |
         A ConstructionMetadataRequest is utilized to get information required
-        to construct a transaction. The Options object used to specify which
-        metadata to return is left purposely unstructured to allow flexibility
-        for implementers.
+        to construct a transaction.
+
+        The Options object used to specify which metadata to return is left
+        purposely unstructured to allow flexibility for implementers. Options
+        is not required in the case that there is network-wide metadata of
+        interest.
 
         Optionally, the request can also include an array
         of PublicKeys associated with the AccountIdentifiers
@@ -887,7 +890,6 @@ components:
       type: object
       required:
         - network_identifier
-        - options
       properties:
         network_identifier:
           $ref: '#/components/schemas/NetworkIdentifier'


### PR DESCRIPTION
@matheusd brought up the strange lack of "required" parity between `ConstructionPreprocessResponse.Options` and `ConstructionMetadataRequest.Options` in https://github.com/coinbase/rosetta-sdk-go/pull/166. This was originally intended so the caller to opt to avoid calling `/construction/metadata` if there were no `ConstructionPreprocessResponse.Options`.

As a result of the conversation on that PR, we've decided it is best to not make `Options` required in `ConstructionMetadataRequest` in the case that an implementer does not need to pass any info related to the `/construction/preprocess` execution. As a side note, this means we can remove the conditional nature of the `Construction API` flow.

### Changes
- [x] Ensure parity between `Options` requirement