### PR TITLE
Support Account Balance Tracking "Exemptions"

### DIFF
--- a/api.json
+++ b/api.json
@@ -1356,12 +1356,12 @@
         }
       },
      "ExemptionType": {
-       "description":"ExemptionType is used to indicate if the live balance for an account subject to a BalanceExemption could increase above, decrease below, or equal the computed balance. * greater_or_equal: The live balance may increase above or equal the computed balance. This typically   occurs with staking rewards that accrue on each block. * less_or_equal: The live balance may decrease below or equal the computed balance. This typically   occurs as balance moves from locked to spendable on a vesting account. * any: The live balance may increase above, decrease below, or equal the computed balance. This   typically occurs with tokens that have a dynamic supply.",
+       "description":"ExemptionType is used to indicate if the live balance for an account subject to a BalanceExemption could increase above, decrease below, or equal the computed balance. * greater_or_equal: The live balance may increase above or equal the computed balance. This typically   occurs with staking rewards that accrue on each block. * less_or_equal: The live balance may decrease below or equal the computed balance. This typically   occurs as balance moves from locked to spendable on a vesting account. * dynamic: The live balance may increase above, decrease below, or equal the computed balance. This   typically occurs with tokens that have a dynamic supply.",
        "type":"string",
        "enum": [
          "greater_or_equal",
          "less_or_equal",
-         "any"
+         "dynamic"
         ]
       },
      "AccountBalanceRequest": {

--- a/api.json
+++ b/api.json
@@ -1124,7 +1124,8 @@
          "operation_types",
          "errors",
          "historical_balance_lookup",
-         "call_methods"
+         "call_methods",
+         "balance_exemptions"
         ],
        "properties": {
          "operation_statuses": {
@@ -1159,6 +1160,13 @@
            "items": {
              "type":"string",
              "example":"eth_call"
+            }
+          },
+         "balance_exemptions": {
+           "type":"array",
+           "description":"BalanceExemptions is an array of BalanceExemption indicating which account balances could change without a corresponding Operation. BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes. If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier).",
+           "items": {
+             "$ref":"#/components/schemas/BalanceExemption"
             }
           }
         }
@@ -1329,6 +1337,32 @@
            "$ref":"#/components/schemas/Amount"
           }
         }
+      },
+     "BalanceExemption": {
+       "description":"BalanceExemption indicates that the balance for an exempt account could change without a corresponding Operation. This typically occurs with staking rewards, vesting balances, and Currencies with a dynamic supply. Currently, it is possible to exempt an account from strict reconciliation by SubAccountIdentifier.Address or by Currency. This means that any account with SubAccountIdentifier.Address would be exempt or any balance of a particular Currency would be exempt, respectively. BalanceExemptions should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile all account balance changes. If your implementation relies on any BalanceExemptions, you MUST implement historical balance lookup (the ability to query an account balance at any BlockIdentifier).",
+       "type":"object",
+       "properties": {
+         "sub_account_address": {
+           "description":"SubAccountAddress is the SubAccountIdentifier.Address that the BalanceExemption applies to (regardless of the value of SubAccountIdentifier.Metadata).",
+           "type":"string",
+           "example":"staking"
+          },
+         "currency": {
+           "$ref":"#/components/schemas/Currency"
+          },
+         "exemption_type": {
+           "$ref":"#/components/schemas/ExemptionType"
+          }
+        }
+      },
+     "ExemptionType": {
+       "description":"ExemptionType is used to indicate if the live balance for an account subject to a BalanceExemption could increase above, decrease below, or equal the computed balance. * greater_or_equal: The live balance may increase above or equal the computed balance. This typically   occurs with staking rewards that accrue on each block. * less_or_equal: The live balance may decrease below or equal the computed balance. This typically   occurs as balance moves from locked to spendable on a vesting account. * any: The live balance may increase above, decrease below, or equal the computed balance. This   typically occurs with tokens that have a dynamic supply.",
+       "type":"string",
+       "enum": [
+         "greater_or_equal",
+         "less_or_equal",
+         "any"
+        ]
       },
      "AccountBalanceRequest": {
        "description":"An AccountBalanceRequest is utilized to make a balance request on the /account/balance endpoint. If the block_identifier is populated, a historical balance query should be performed.",

--- a/api.yaml
+++ b/api.yaml
@@ -671,6 +671,10 @@ components:
       $ref: 'models/CoinChange.yaml'
     Coin:
       $ref: 'models/Coin.yaml'
+    BalanceExemption:
+      $ref: 'models/BalanceExemption.yaml'
+    ExemptionType:
+      $ref: 'models/ExemptionType.yaml'
 
     # Request/Responses
     AccountBalanceRequest:

--- a/models/Allow.yaml
+++ b/models/Allow.yaml
@@ -70,8 +70,15 @@ properties:
   balance_exemptions:
     type: array
     description: |
-      blah 
+      BalanceExemptions is an array of BalanceExemption indicating
+      which account could change without a corresponding Operation.
 
-      if exemptions provided, you MUST support historical balance lookup.
+      BalanceExemptions should be used sparingly as they may
+      introduce significant complexity for integrators that attempt
+      to reconcile all account balance changes.
+
+      If your implementation relies on any BalanceExemptions, you MUST implement
+      historical balance lookup (the ability to query an account balance at any
+      BlockIdentifier).
     items:
       $ref: 'BalanceExemption.yaml'

--- a/models/Allow.yaml
+++ b/models/Allow.yaml
@@ -71,7 +71,7 @@ properties:
     type: array
     description: |
       BalanceExemptions is an array of BalanceExemption indicating
-      which account could change without a corresponding Operation.
+      which account balances could change without a corresponding Operation.
 
       BalanceExemptions should be used sparingly as they may
       introduce significant complexity for integrators that attempt

--- a/models/Allow.yaml
+++ b/models/Allow.yaml
@@ -25,6 +25,7 @@ required:
   - errors
   - historical_balance_lookup
   - call_methods
+  - balance_exemptions
 properties:
   operation_statuses:
     description: |
@@ -66,3 +67,11 @@ properties:
     items:
       type: string
       example: "eth_call"
+  balance_exemptions:
+    type: array
+    description: |
+      blah 
+
+      if exemptions provided, you MUST support historical balance lookup.
+    items:
+      $ref: 'BalanceExemption.yaml'

--- a/models/BalanceExemption.yaml
+++ b/models/BalanceExemption.yaml
@@ -1,19 +1,22 @@
 description: |
   BalanceExemption indicates that the balance for a particular account could
   change without a corresponding Operation. This typically occurs with staking
-  rewards, vesting accounts, and currencies with a dynamic supply.
+  rewards, vesting balances, and Currencies with a dynamic supply.
 
-  BalanceExemptions should be used extremely conservatively as they may
-  introduce significant complexity for integrators.
+  BalanceExemptions should be used sparingly as they may
+  introduce significant complexity for integrators that attempt
+  to reconcile all account balance changes.
 
-  If you rely on any BalanceExemptions, you MUST implement historical
-  balance lookup.
+  If your implementation relies on any BalanceExemptions, you MUST implement
+  historical balance lookup (the ability to query an account balance at any
+  BlockIdentifier).
 type: object
 properties:
   sub_account_address:
     description: |
-      # TODO: this should be sub account address so that we can cover 
-      # all subaccounts regardless of metadata
+      SubAccountAddress is the SubAccountIdentifier.Address that the
+      BalanceExemption applies to (regardless of the value of
+      SubAccountIdentifer.Metadata).
     type: string
     example: "staking"
   currency:

--- a/models/BalanceExemption.yaml
+++ b/models/BalanceExemption.yaml
@@ -1,9 +1,21 @@
 description: |
-  blah
+  BalanceExemption indicates that the balance for a particular account could
+  change without a corresponding Operation. This typically occurs with staking
+  rewards, vesting accounts, and currencies with a dynamic supply.
+
+  BalanceExemptions should be used extremely conservatively as they may
+  introduce significant complexity for integrators.
+
+  If you rely on any BalanceExemptions, you MUST implement historical
+  balance lookup.
 type: object
 properties:
-  sub_account_identifier:
-    $ref: 'SubAccountIdentifier.yaml' 
+  sub_account_address:
+    description: |
+      # TODO: this should be sub account address so that we can cover 
+      # all subaccounts regardless of metadata
+    type: string
+    example: "staking"
   currency:
     $ref: 'Currency.yaml'
   exemption_type:

--- a/models/BalanceExemption.yaml
+++ b/models/BalanceExemption.yaml
@@ -1,0 +1,10 @@
+description: |
+  blah
+type: object
+properties:
+  sub_account_identifier:
+    $ref: 'SubAccountIdentifier.yaml' 
+  currency:
+    $ref: 'Currency.yaml'
+  exemption_type:
+    $ref: 'ExemptionType.yaml'

--- a/models/BalanceExemption.yaml
+++ b/models/BalanceExemption.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 description: |
   BalanceExemption indicates that the balance for a particular account could
   change without a corresponding Operation. This typically occurs with staking

--- a/models/BalanceExemption.yaml
+++ b/models/BalanceExemption.yaml
@@ -13,9 +13,14 @@
 # limitations under the License.
 
 description: |
-  BalanceExemption indicates that the balance for a particular account could
+  BalanceExemption indicates that the balance for an exempt account could
   change without a corresponding Operation. This typically occurs with staking
   rewards, vesting balances, and Currencies with a dynamic supply.
+
+  Currently, it is possible to exempt an account from strict reconciliation
+  by SubAccountIdentifier.Address or by Currency. This means that any account
+  with SubAccountIdentifier.Address would be exempt or any balance of a particular
+  Currency would be exempt, respectively.
 
   BalanceExemptions should be used sparingly as they may
   introduce significant complexity for integrators that attempt
@@ -30,7 +35,7 @@ properties:
     description: |
       SubAccountAddress is the SubAccountIdentifier.Address that the
       BalanceExemption applies to (regardless of the value of
-      SubAccountIdentifer.Metadata).
+      SubAccountIdentifier.Metadata).
     type: string
     example: "staking"
   currency:

--- a/models/ExemptionType.yaml
+++ b/models/ExemptionType.yaml
@@ -3,9 +3,12 @@ description: |
   BalanceExemption could increase above, decrease below, or
   equal the computed balance.
 
-  * greater_or_equal: The live balance may increase above or equal the computed balance.
-  * less_or_equal: The live balance may decrease below or equal the computed balance.
-  * any: The live balance may increase above, decrease below, or equal the computed balance.
+  * greater_or_equal: The live balance may increase above or equal the computed balance. This typically
+    occurs with staking rewards that accrue on each block.
+  * less_or_equal: The live balance may decrease below or equal the computed balance. This typically
+    occurs as balance moves from locked to spendable on a vesting account.
+  * any: The live balance may increase above, decrease below, or equal the computed balance. This
+    typically occurs with tokens that have a dynamic supply. 
 type: string
 enum:
   - greater_or_equal

--- a/models/ExemptionType.yaml
+++ b/models/ExemptionType.yaml
@@ -13,18 +13,18 @@
 # limitations under the License.
 
 description: |
-  ExemptionType is used to indicate if the live balance for a
-  BalanceExemption could increase above, decrease below, or
-  equal the computed balance.
+  ExemptionType is used to indicate if the live balance for an
+  account subject to a BalanceExemption could increase above,
+  decrease below, or equal the computed balance.
 
   * greater_or_equal: The live balance may increase above or equal the computed balance. This typically
     occurs with staking rewards that accrue on each block.
   * less_or_equal: The live balance may decrease below or equal the computed balance. This typically
     occurs as balance moves from locked to spendable on a vesting account.
   * any: The live balance may increase above, decrease below, or equal the computed balance. This
-    typically occurs with tokens that have a dynamic supply. 
+    typically occurs with tokens that have a dynamic supply.
 type: string
 enum:
   - greater_or_equal
   - less_or_equal
-  - any 
+  - any

--- a/models/ExemptionType.yaml
+++ b/models/ExemptionType.yaml
@@ -21,10 +21,10 @@ description: |
     occurs with staking rewards that accrue on each block.
   * less_or_equal: The live balance may decrease below or equal the computed balance. This typically
     occurs as balance moves from locked to spendable on a vesting account.
-  * any: The live balance may increase above, decrease below, or equal the computed balance. This
+  * dynamic: The live balance may increase above, decrease below, or equal the computed balance. This
     typically occurs with tokens that have a dynamic supply.
 type: string
 enum:
   - greater_or_equal
   - less_or_equal
-  - any
+  - dynamic

--- a/models/ExemptionType.yaml
+++ b/models/ExemptionType.yaml
@@ -1,0 +1,13 @@
+description: |
+  ExemptionType is used to indicate if the live balance for a
+  BalanceExemption could increase above, decrease below, or
+  equal the computed balance.
+
+  * greater_or_equal: The live balance may increase above or equal the computed balance.
+  * less_or_equal: The live balance may decrease below or equal the computed balance.
+  * any: The live balance may increase above, decrease below, or equal the computed balance.
+type: string
+enum:
+  - greater_or_equal
+  - less_or_equal
+  - any 

--- a/models/ExemptionType.yaml
+++ b/models/ExemptionType.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 description: |
   ExemptionType is used to indicate if the live balance for a
   BalanceExemption could increase above, decrease below, or


### PR DESCRIPTION
Fixes: #53 

This PR adds support for "exempting" account balances identified by a certain `SubAccount.Identifier` or `Currency` from strict balance tracking (instead subjecting them to tracking that reflects the specified `ExemptionType`). In other words, it is now possible to specify which account balances may change without corresponding operations (i.e. staking rewards, vesting balances, tokens with dynamic supply).

`BalanceExemptions` should be used sparingly as they may introduce significant complexity for integrators that attempt to reconcile (compare computed balance with live balance) the balance of accounts they care about.