### PR TITLE
Replace broken link for commit guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,5 +49,5 @@ be locked to prevent further discussion.
 All support requests must be made via [our support team][3].
 
 [1]: https://github.com/coinbase/rosetta-specifications/issues
-[2]: https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25
+[2]: https://chris.beams.io/posts/git-commit/#seven-rules
 [3]: https://support.coinbase.com/customer/en/portal/articles/2288496-how-can-i-contact-coinbase-support-


### PR DESCRIPTION
### Motivation
The contribution guidelines suggest that contributors 
`Ensure your [commit messages are well-written](https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25).`

The medium link redirects to an expired domain.

### Solution
This PR replaces the broken link with the latest version saved by archive.org: https://web.archive.org/web/20160316232453/https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25

I've opened a PR as this is a quick fix, but happy to open an issue instead if that's preferred.

### In other repos
[The rosetta website](https://www.rosetta-api.org/docs/contributing.html#pull-requests) and other rosetta repos also use the broken link (in [rosetta-cli](https://github.com/coinbase/rosetta-cli/blob/master/CONTRIBUTING.md#pull-requests), in [rosetta-sdk-go](https://github.com/coinbase/rosetta-sdk-go/blob/master/CONTRIBUTING.md#pull-requests), in [rosetta-bitcoin](https://github.com/coinbase/rosetta-bitcoin/blob/master/CONTRIBUTING.md#pull-requests)). If this PR is helpful, I'll make the same fix in the other rosetta repos, unless there's a better solution.