### PR TITLE
Make `Operation.Status` optional

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.6",
+   "version":"1.4.7",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {
@@ -941,12 +941,11 @@
         }
       },
      "Operation": {
-       "description":"Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction.",
+       "description":"Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction. Operations are used both to represent on-chain data (Data API) and to construct new transactions (Construction API), creating a standard interface for reading and writing to blockchains.",
        "type":"object",
        "required": [
          "operation_identifier",
-         "type",
-         "status"
+         "type"
         ],
        "properties": {
          "operation_identifier": {
@@ -968,12 +967,12 @@
             ]
           },
          "type": {
-           "description":"The network-specific type of the operation. Ensure that any type that can be returned here is also specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all block data.",
+           "description":"Type is the network-specific type of the operation. Ensure that any type that can be returned here is also specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all block data.",
            "type":"string",
            "example":"Transfer"
           },
          "status": {
-           "description":"The network-specific status of the operation. Status is not defined on the transaction object because blockchains with smart contracts may have transactions that partially apply. Blockchains with atomic transactions (all operations succeed or all operations fail) will have the same status for each operation.",
+           "description":"Status is the network-specific status of the operation. Status is not defined on the transaction object because blockchains with smart contracts may have transactions that partially apply (some operations are successful and some are not). Blockchains with atomic transactions (all operations succeed or all operations fail) will have the same status for each operation. On-chain operations (operations retrieved in the `/block` and `/block/transaction` endpoints) MUST have a populated status field (anything on-chain must have succeeded or failed). However, operations provided during transaction construction (often times called \"intent\" in the documentation) MUST NOT have a populated status field (operations yet to be included on-chain have not yet succeeded or failed).",
            "type":"string",
            "example":"Reverted"
           },

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.6
+  version: 1.4.7
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.

--- a/models/Operation.yaml
+++ b/models/Operation.yaml
@@ -16,11 +16,14 @@ description: |
   Operations contain all balance-changing information within a
   transaction. They are always one-sided (only affect 1 AccountIdentifier)
   and can succeed or fail independently from a Transaction.
+
+  Operations are used both to represent on-chain data (Data API) and to construct
+  new transactions (Construction API), creating a standard interface for reading
+  and writing to blockchains.
 type: object
 required:
   - operation_identifier
   - type
-  - status
 properties:
   operation_identifier:
     $ref: 'OperationIdentifier.yaml'
@@ -40,18 +43,22 @@ properties:
       - index: 2
   type:
     description: |
-      The network-specific type of the operation. Ensure that any type that can be returned here is also
+      Type is the network-specific type of the operation. Ensure that any type that can be returned here is also
       specified in the NetworkOptionsResponse. This can be very useful to downstream consumers that parse all
       block data.
     type: string
     example: "Transfer"
   status:
     description: |
-      The network-specific status of the operation. Status is not defined on the transaction object
-      because blockchains with smart contracts may have transactions that partially apply.
+      Status is the network-specific status of the operation. Status is not defined on the transaction object
+      because blockchains with smart contracts may have transactions that partially apply (some operations
+      are successful and some are not). Blockchains with atomic transactions (all operations succeed or
+      all operations fail) will have the same status for each operation.
 
-      Blockchains with atomic transactions (all operations succeed or all operations fail) will have
-      the same status for each operation.
+      On-chain operations (operations retrieved in the `/block` and `/block/transaction` endpoints) MUST have
+      a populated status field (anything on-chain must have succeeded or failed). However, operations provided
+      during transaction construction (often times called "intent" in the documentation) MUST NOT
+      have a populated status field (operations yet to be included on-chain have not yet succeeded or failed).
     type: string
     example: "Reverted"
   account:


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-cli/issues/180

This PR updates `Operation.Status` to be considered optional. We've been treating this field as optional since the introduction of the Construction API ("intent" should not have a populated `Operation.Status`) but have yet to update the spec to reflect this.

### Changes
- [x] make `Operation.Status` optional
- [x] Update version