### PR TITLE
/account/balance + /account/coins restricted queries

### DIFF
--- a/api.json
+++ b/api.json
@@ -1432,6 +1432,13 @@
           },
          "block_identifier": {
            "$ref":"#/components/schemas/PartialBlockIdentifier"
+          },
+         "currencies": {
+           "type":"array",
+           "description":"In some cases, the caller may not want to retrieve all available balances for an AccountIdentifier. If the currencies field is populated, only balances for the specified currencies will be returned. If not populated, all available balances will be returned.",
+           "items": {
+             "$ref":"#/components/schemas/Currency"
+            }
           }
         }
       },
@@ -1480,6 +1487,13 @@
          "include_mempool": {
            "type":"boolean",
            "description":"Include state from the mempool when looking up an account's unspent coins. Note, using this functionality breaks any guarantee of idempotency."
+          },
+         "currencies": {
+           "type":"array",
+           "description":"In some cases, the caller may not want to retrieve coins for all currencies for an AccountIdentifier. If the currencies field is populated, only coins for the specified currencies will be returned. If not populated, all unspent coins will be returned.",
+           "items": {
+             "$ref":"#/components/schemas/Currency"
+            }
           }
         }
       },

--- a/api.yaml
+++ b/api.yaml
@@ -736,6 +736,16 @@ components:
           $ref: '#/components/schemas/AccountIdentifier'
         block_identifier:
           $ref: '#/components/schemas/PartialBlockIdentifier'
+        currencies:
+          type: array
+          description: |
+            In some cases, the caller may not want to retrieve all available
+            balances for an AccountIdentifier. If the currencies field
+            is populated, only balances for the specified currencies
+            will be returned. If not populated, all available balances
+            will be returned.
+          items:
+            $ref: '#/components/schemas/Currency'
     AccountBalanceResponse:
       description: |
         An AccountBalanceResponse is returned on the /account/balance endpoint.
@@ -785,6 +795,16 @@ components:
             Include state from the mempool when looking up an account's
             unspent coins. Note, using this functionality
             breaks any guarantee of idempotency.
+        currencies:
+          type: array
+          description: |
+            In some cases, the caller may not want to retrieve coins for all
+            currencies for an AccountIdentifier. If the currencies field
+            is populated, only coins for the specified currencies
+            will be returned. If not populated, all unspent coins
+            will be returned.
+          items:
+            $ref: '#/components/schemas/Currency'
     AccountCoinsResponse:
       description: |
         AccountCoinsResponse is returned on the /account/coins endpoint and includes


### PR DESCRIPTION
This PR adds support for specifying that only a subset of balances and coins be returned for a particular AccountIdentifier. This can be particularly effective for a Rosetta Module that supports hundreds of tokens (each requiring a call to the node to get balance)!