### PR TITLE
Indexer Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ this illustration:
 
 ## Indexers
 For some developers, the existing Data API and Construction API endpoints are not
-sufficent to fully support an asset integration. It is not possible, for example,
+sufficient to fully support an asset integration. It is not possible, for example,
 to search for a transaction by hash or access all transactions that affected
 a particular account. Traditionally database-intensive functionality was purposely
 excluded from the collection of endpoints any Rosetta implementation must complete

--- a/README.md
+++ b/README.md
@@ -227,7 +227,14 @@ to write a generic indexer for any Rosetta implementation.
 To avoid a proliferation of interfaces that service Rosetta in this layer,
 we've defined a set of standard "indexer" endpoints that enable developers
 to automatically integrate (with the SDK they already use to access the
-Rosetta API).
+Rosetta API). **Rosetta implementations are not required to implement "indexer" endpoints
+but are welcome to do so!**
+
+Indexer implementations must proxy non-indexer Data API and
+Construction API calls to the implementation of interest (potentially
+caching some data) so that developers do not need to connect to multiple
+endpoints to access Rosetta. All calls contain a `NetworkIdentifier` so it
+should be possible to route requests without too much difficulty.
 
 ### Required Endpoints
 * Data API (proxied)
@@ -237,15 +244,6 @@ Rosetta API).
 
 _If you think an endpoint is missing from this list, please reach out
 on our [community](https://community.rosetta-api.org/)._
-
-Indexer implementations must proxy non-indexer Data API and
-Construction API calls to the implementation of interest (potentially
-caching some data) so that developers do not need to connect to multiple
-endpoints to access Rosetta. All calls contain a `NetworkIdentifier` so it
-should be possible to route requests without too much difficulty.
-
-**Rosetta implementations do not need to implement "indexer" endpoints
-but are welcome to do so!**
 
 ## Documentation
 Now that you have some familiarity with the flow of operations, we recommend taking a look at the Rosetta API Docs:

--- a/README.md
+++ b/README.md
@@ -213,6 +213,40 @@ this illustration:
 
 ![Rosetta Modules](images/rosetta-modules.png)
 
+## Indexers
+For some developers, the existing Data API and Construction API endpoints are not
+sufficent to fully support an asset integration. It is not possible, for example,
+to search for a transaction by hash or access all transactions that affected
+a particular account. Traditionally database-intensive functionality was purposely
+excluded from the collection of endpoints any Rosetta implementation must complete
+as to avoid imposing cumbersome requirements on Rosetta implementers (that could require
+maintaining architecture alongside their core node).
+
+Because of the standardization introduced by Rosetta, it is possible
+to write a generic indexer for any Rosetta implementation.
+To avoid a proliferation of interfaces that service Rosetta in this layer,
+we've defined a set of standard "indexer" endpoints that enable developers
+to automatically integrate (with the SDK they already use to access the
+Rosetta API).
+
+### Required Endpoints
+* Data API (proxied)
+* Construction API (proxied)
+* `/events/*`
+* `/search/*`
+
+_If you think an endpoint is missing from this list, please reach out
+on our [community](https://community.rosetta-api.org/)._
+
+Indexer implementations must proxy non-indexer Data API and
+Construction API calls to the implementation of interest (potentially
+caching some data) so that developers do not need to connect to multiple
+endpoints to access Rosetta. All calls contain a `NetworkIdentifier` so it
+should be possible to route requests without too much difficulty.
+
+**Rosetta implementations do not need to implement "indexer" endpoints
+but are welcome to do so!**
+
 ## Documentation
 Now that you have some familiarity with the flow of operations, we recommend taking a look at the Rosetta API Docs:
 
@@ -325,6 +359,8 @@ endpoints (other than `/construction/metadata` and `/construction/submit`).
 * `/construction/submit`
 
 #### Offline Mode Endpoints
+* `/network/list`
+* `/network/options`
 * `/construction/derive`
 * `/construction/preprocess`
 * `/construction/payloads`

--- a/api.json
+++ b/api.json
@@ -765,6 +765,90 @@
           }
         }
       }
+    },
+   "/events/blocks": {
+     "post": {
+       "summary":"[INDEXER] Get a range of BlockEvents",
+       "description":"`/events/blocks` allows the caller to query a stream of BlockEvents indicating which blocks were added and removed from storage to reach the indexer's current state. Streaming BlockEvents allows lightweight clients to update their state without needing to implement their own syncing logic (like finding the common parent in a reorg). `/events/blocks` is considered an \"indexer\" endpoint and Rosetta implementations are not required to complete it to adhere to the Rosetta spec. However, any Rosetta \"indexer\" MUST support this endpoint.",
+       "operationId":"eventsBlocks",
+       "tags": [
+         "Events"
+        ],
+       "requestBody": {
+         "required": true,
+         "content": {
+           "application/json": {
+             "schema": {
+               "$ref":"#/components/schemas/EventsBlocksRequest"
+              }
+            }
+          }
+        },
+       "responses": {
+         "200": {
+           "description":"Expected response to a valid request",
+           "content": {
+             "application/json": {
+               "schema": {
+                 "$ref":"#/components/schemas/EventsBlocksResponse"
+                }
+              }
+            }
+          },
+         "500": {
+           "description":"unexpected error",
+           "content": {
+             "application/json": {
+               "schema": {
+                 "$ref":"#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+   "/search/transactions": {
+     "post": {
+       "summary":"[INDEXER] Search for Transactions",
+       "description":"`/search/transactions` allows the caller to search for transactions that meet certain conditions. Some conditions include matching a transaction hash, containing an operation with a certain status, or containing an operation that affects a certain account. `/search/transactions` is considered an \"indexer\" endpoint and Rosetta implementations are not required to complete it to adhere to the Rosetta spec. However, any Rosetta \"indexer\" MUST support this endpoint.",
+       "operationId":"searchTransactions",
+       "tags": [
+         "Search"
+        ],
+       "requestBody": {
+         "required": true,
+         "content": {
+           "application/json": {
+             "schema": {
+               "$ref":"#/components/schemas/SearchTransactionsRequest"
+              }
+            }
+          }
+        },
+       "responses": {
+         "200": {
+           "description":"Expected response to a valid request",
+           "content": {
+             "application/json": {
+               "schema": {
+                 "$ref":"#/components/schemas/SearchTransactionsResponse"
+                }
+              }
+            }
+          },
+         "500": {
+           "description":"unexpected error",
+           "content": {
+             "application/json": {
+               "schema": {
+                 "$ref":"#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
  "components": {
@@ -1415,6 +1499,62 @@
          "less_or_equal",
          "dynamic"
         ]
+      },
+     "BlockEvent": {
+       "description":"BlockEvent represents the addition or removal of a BlockIdentifier from the stored state of an indexer. Streaming BlockEvents allows lightweight clients to update their own state without needing to implement their own syncing logic.",
+       "type":"object",
+       "required": [
+         "sequence",
+         "block_identifier",
+         "type"
+        ],
+       "properties": {
+         "sequence": {
+           "description":"sequence is the unique identifier of a BlockEvent within the context of a NetworkIdentifier.",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
+          },
+         "block_identifier": {
+           "$ref":"#/components/schemas/BlockIdentifier"
+          },
+         "type": {
+           "$ref":"#/components/schemas/BlockEventType"
+          }
+        }
+      },
+     "BlockEventType": {
+       "description":"BlockEventType determines if a BlockEvent represents the addition or removal of a block.",
+       "type":"string",
+       "enum": [
+         "block_added",
+         "block_removed"
+        ]
+      },
+     "Operator": {
+       "description":"Operator is used by query-related endpoints to determine how to apply conditions.",
+       "type":"string",
+       "enum": [
+         "or",
+         "and"
+        ]
+      },
+     "BlockTransaction": {
+       "description":"BlockTransaction contains a populated Transaction and the BlockIdentifier that contains it.",
+       "type":"object",
+       "required": [
+         "block_identifier",
+         "transaction"
+        ],
+       "properties": {
+         "block_identifier": {
+           "$ref":"#/components/schemas/BlockIdentifier"
+          },
+         "transaction": {
+           "$ref":"#/components/schemas/Transaction"
+          }
+        }
       },
      "AccountBalanceRequest": {
        "description":"An AccountBalanceRequest is utilized to make a balance request on the /account/balance endpoint. If the block_identifier is populated, a historical balance query should be performed.",
@@ -2081,6 +2221,144 @@
          "idempotent": {
            "type":"boolean",
            "description":"Idempotent indicates that if `/call` is invoked with the same CallRequest again, at any point in time, it will return the same CallResponse. Integrators may cache the CallResponse if this is set to true to avoid making unnecessary calls to the Rosetta implementation. For this reason, implementers should be very conservative about returning true here or they could cause issues for the caller."
+          }
+        }
+      },
+     "EventsBlocksRequest": {
+       "description":"EventsBlocksRequest is utilized to fetch a sequence of BlockEvents indicating which blocks were added and removed during syncing.",
+       "type":"object",
+       "required": [
+         "network_identifier"
+        ],
+       "properties": {
+         "network_identifier": {
+           "$ref":"#/components/schemas/NetworkIdentifier"
+          },
+         "offset": {
+           "description":"offset is the offset into the event stream to sync events from. If this is left empty, we stream the limit from tip. If this is set to 0, we start from the beginning.",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
+          },
+         "limit": {
+           "description":"limit is the maximum number of events to fetch in one call. The implementation may return <= limit events.",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
+          }
+        }
+      },
+     "EventsBlocksResponse": {
+       "description":"EventsBlocksResponse contains an ordered collection of BlockEvents and the max retrievable sequence.",
+       "type":"object",
+       "required": [
+         "max_sequence",
+         "events"
+        ],
+       "properties": {
+         "max_sequence": {
+           "description":"max_sequence is the maximum available sequence number to fetch.",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
+          },
+         "events": {
+           "type":"array",
+           "description":"events is an array of BlockEvents indicating the order to add and remove blocks to maintain a canonical view of blockchain state. Lightweight clients can use this event stream to update state without implementing their own block syncing logic.",
+           "items": {
+             "$ref":"#/components/schemas/BlockEvent"
+            }
+          }
+        }
+      },
+     "SearchTransactionsRequest": {
+       "description":"SearchTransactionsRequest is used to search for transactions matching a set of provided conditions in canonical blocks.",
+       "type":"object",
+       "required": [
+         "network_identifier",
+         "operator"
+        ],
+       "properties": {
+         "network_identifier": {
+           "$ref":"#/components/schemas/NetworkIdentifier"
+          },
+         "operator": {
+           "$ref":"#/components/schemas/Operator"
+          },
+         "max_block": {
+           "description":"max_block is the largest block index to consider when searching for transactions. If this field is not populated, the current block is considered the max_block. If you do not specify a max_block, it is possible a newly synced block will interfere with paginated transaction queries (as the offset could become invalid with newly added rows).",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
+          },
+         "offset": {
+           "description":"offset is the offset into the query result to start returning transactions. If any search conditions are changed, the query offset will change and you must restart your search iteration.",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
+          },
+         "limit": {
+           "description":"limit is the maximum number of transactions to return in one call. The implementation may return <= limit transactions.",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
+          },
+         "transaction_identifier": {
+           "$ref":"#/components/schemas/TransactionIdentifier"
+          },
+         "account_identifier": {
+           "$ref":"#/components/schemas/AccountIdentifier"
+          },
+         "currency": {
+           "$ref":"#/components/schemas/Currency"
+          },
+         "status": {
+           "type":"string",
+           "description":"status is the network-specific operation type.",
+           "example":"reverted"
+          },
+         "type": {
+           "type":"string",
+           "description":"type is the network-specific operation type.",
+           "example":"transfer"
+          },
+         "address": {
+           "type":"string",
+           "description":"address is AccountIdentifier.Address. This is used to get all transactions related to an AccountIdentifier.Address, regardless of SubAccountIdentifier.",
+           "example":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+          },
+         "success": {
+           "type":"boolean",
+           "description":"success is a synthetic condition populated by parsing network-specific operation statuses (using the mapping provided in `/network/options`)."
+          }
+        }
+      },
+     "SearchTransactionsResponse": {
+       "description":"SearchTransactionsResponse contains an ordered collection of BlockTransactions that match the query in SearchTransactionsRequest. These BlockTransactions are sorted from most recent block to oldest block.",
+       "type":"object",
+       "required": [
+         "transactions"
+        ],
+       "properties": {
+         "next_offset": {
+           "description":"next_offset is the next offset to use when paginating through transaction results. If this field is not populated, there are no more transactions to query.",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
+          },
+         "transactions": {
+           "type":"array",
+           "description":"transactions is an array of BlockTransactions sorted by most recent BlockIdentifier (meaning that transactions in recent blocks appear first). If there are many transactions for a particular search, transactions may not contain all matching transactions. It is up to the caller to paginate these transactions using the max_block field.",
+           "items": {
+             "$ref":"#/components/schemas/BlockTransaction"
+            }
           }
         }
       },

--- a/api.json
+++ b/api.json
@@ -769,7 +769,7 @@
    "/events/blocks": {
      "post": {
        "summary":"[INDEXER] Get a range of BlockEvents",
-       "description":"`/events/blocks` allows the caller to query a stream of BlockEvents indicating which blocks were added and removed from storage to reach the indexer's current state. Streaming BlockEvents allows lightweight clients to update their state without needing to implement their own syncing logic (like finding the common parent in a reorg). `/events/blocks` is considered an \"indexer\" endpoint and Rosetta implementations are not required to complete it to adhere to the Rosetta spec. However, any Rosetta \"indexer\" MUST support this endpoint.",
+       "description":"`/events/blocks` allows the caller to query a sequence of BlockEvents indicating which blocks were added and removed from storage to reach the current state. Following BlockEvents allows lightweight clients to update their state without needing to implement their own syncing logic (like finding the common parent in a reorg). `/events/blocks` is considered an \"indexer\" endpoint and Rosetta implementations are not required to complete it to adhere to the Rosetta spec. However, any Rosetta \"indexer\" MUST support this endpoint.",
        "operationId":"eventsBlocks",
        "tags": [
          "Events"
@@ -1501,7 +1501,7 @@
         ]
       },
      "BlockEvent": {
-       "description":"BlockEvent represents the addition or removal of a BlockIdentifier from the stored state of an indexer. Streaming BlockEvents allows lightweight clients to update their own state without needing to implement their own syncing logic.",
+       "description":"BlockEvent represents the addition or removal of a BlockIdentifier from storage. Streaming BlockEvents allows lightweight clients to update their own state without needing to implement their own syncing logic.",
        "type":"object",
        "required": [
          "sequence",
@@ -2225,7 +2225,7 @@
         }
       },
      "EventsBlocksRequest": {
-       "description":"EventsBlocksRequest is utilized to fetch a sequence of BlockEvents indicating which blocks were added and removed during syncing.",
+       "description":"EventsBlocksRequest is utilized to fetch a sequence of BlockEvents indicating which blocks were added and removed from storage to reach the current state.",
        "type":"object",
        "required": [
          "network_identifier"
@@ -2235,7 +2235,7 @@
            "$ref":"#/components/schemas/NetworkIdentifier"
           },
          "offset": {
-           "description":"offset is the offset into the event stream to sync events from. If this is left empty, we stream the limit from tip. If this is set to 0, we start from the beginning.",
+           "description":"offset is the offset into the event stream to sync events from. If this field is not populated, we return the limit events backwards from tip. If this is set to 0, we start from the beginning.",
            "type":"integer",
            "format":"int64",
            "minimum": 0,

--- a/api.json
+++ b/api.json
@@ -2315,6 +2315,9 @@
          "account_identifier": {
            "$ref":"#/components/schemas/AccountIdentifier"
           },
+         "coin_identifier": {
+           "$ref":"#/components/schemas/CoinIdentifier"
+          },
          "currency": {
            "$ref":"#/components/schemas/Currency"
           },

--- a/api.yaml
+++ b/api.yaml
@@ -795,6 +795,10 @@ components:
       $ref: 'models/BlockEvent.yaml'
     BlockEventType:
       $ref: 'models/BlockEventType.yaml'
+    Operator:
+      $ref: 'models/Operator.yaml'
+    BlockTransaction:
+      $ref: 'models/BlockTransaction.yaml'
 
     # Request/Responses
     AccountBalanceRequest:
@@ -1532,6 +1536,97 @@ components:
             state without implementing their own block syncing logic.
           items:
             $ref: '#/components/schemas/BlockEvent'
+    SearchTransactionsRequest:
+      description: |
+        SearchTransactionsRequest is used to search for transactions
+        matching a set of provided conditions.
+      type: object
+      required:
+        - network_identifier
+        - operator
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        operator:
+          $ref: '#/components/schemas/Operator'
+        max_block:
+          description: |
+            max_block is the largest block index to consider when searching
+            for transactions. If this field is not populated, the current
+            block is considered the max_block.
+          type: integer
+          format: int64
+          minimum: 0
+          example: 5
+        limit:
+          description: |
+            limit is the maximum number of transactions to return in one call. The implementation
+            may return <= limit transactions.
+
+            If returning all transactions in a block would surpass the specified
+            limit (so that only some transactions in a block would be returned),
+            no transactions from that block are returned.
+          type: integer
+          format: int64
+          minimum: 0
+          example: 5
+        transaction_identifier:
+          $ref: '#/components/schemas/TransactionIdentifier'
+        account_identifier:
+          $ref: '#/components/schemas/AccountIdentifier'
+        currency:
+          $ref: '#/components/schemas/Currency'
+        status:
+          type: string
+          description: |
+            status is the network-specific operation type.
+          example: "reverted"
+        type:
+          type: string
+          description: |
+            type is the network-specific operation type.
+          example: "transfer"
+        address:
+          type: string
+          description: |
+            address is AccountIdentifier.Address. This is used to get all
+            transactions related to an AccountIdentifier.Address, regardless
+            of SubAccountIdentifier.
+          example: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        success:
+          type: boolean
+          description: |
+            success is a synthetic condition populated by parsing network-specific
+            operation statuses (using the mapping provided in `/network/options`).
+    SearchTransactionsResponse:
+      description: |
+        SearchTransactionsResponse contains an ordered collection of BlockTransactions
+        that match the query in SearchTransactionsRequest. These BlockTransactions
+        are sorted from most recent block to oldest block.
+      type: object
+      required:
+        - transactions
+      properties:
+        next_max_block:
+          description: |
+            next_max_block is the next max_block to use when querying transactions.
+            If there are no more transactions to fetch, this field is not returned.
+          type: integer
+          format: int64
+          minimum: 0
+          example: 5
+        transactions:
+          type: array
+          description: |
+            transactions is an array of BlockTransactions sorted by most recent
+            BlockIdentifier (meaning that transactions in recent blocks appear
+            first).
+
+            If there are many transactions for a particular search, transactions
+            may not contain all matching transactions. It is up to the caller to
+            paginate these transactions using the max_block field.
+          items:
+            $ref: 'BlockTransaction.yaml'
 
     # Miscellaneous
     Error:

--- a/api.yaml
+++ b/api.yaml
@@ -770,6 +770,10 @@ components:
       $ref: 'models/BalanceExemption.yaml'
     ExemptionType:
       $ref: 'models/ExemptionType.yaml'
+    BlockEventType:
+      $ref: 'models/BlockEventType.yaml'
+    BlockEvent:
+      $ref: 'models/BlockEvent.yaml'
 
     # Request/Responses
     AccountBalanceRequest:
@@ -1455,6 +1459,44 @@ components:
             to avoid making unnecessary calls to the Rosetta implementation. For
             this reason, implementers should be very conservative about returning
             true here or they could cause issues for the caller.
+    EventsBlocksRequest:
+      description: |
+      type: object
+      required:
+        - network_identifier
+      properties:
+        network_identifier:
+          $ref: '#/components/schemas/NetworkIdentifier'
+        offset:
+          description: |
+          type: integer
+          format: int64
+          minimum: 0
+          example: 5
+        limit:
+          description: |
+          type: integer
+          format: int64
+          minimum: 0
+          example: 5
+    EventsBlocksResponse:
+      description: |
+      type: object
+      required:
+        - max_sequence
+        - events
+      properties:
+        max_sequence:
+          description: |
+          type: integer
+          format: int64
+          minimum: 0
+          example: 5
+        events:
+          type: array
+          description: |
+          items:
+            $ref: '#/components/schemas/BlockEvent'
 
     # Miscellaneous
     Error:

--- a/api.yaml
+++ b/api.yaml
@@ -1586,6 +1586,8 @@ components:
           $ref: '#/components/schemas/TransactionIdentifier'
         account_identifier:
           $ref: '#/components/schemas/AccountIdentifier'
+        coin_identifier:
+          $ref: '#/components/schemas/CoinIdentifier'
         currency:
           $ref: '#/components/schemas/Currency'
         status:

--- a/api.yaml
+++ b/api.yaml
@@ -770,10 +770,10 @@ components:
       $ref: 'models/BalanceExemption.yaml'
     ExemptionType:
       $ref: 'models/ExemptionType.yaml'
-    BlockEventType:
-      $ref: 'models/BlockEventType.yaml'
     BlockEvent:
       $ref: 'models/BlockEvent.yaml'
+    BlockEventType:
+      $ref: 'models/BlockEventType.yaml'
 
     # Request/Responses
     AccountBalanceRequest:
@@ -1461,6 +1461,7 @@ components:
             true here or they could cause issues for the caller.
     EventsBlocksRequest:
       description: |
+        EventsBlocksRequest 
       type: object
       required:
         - network_identifier
@@ -1469,18 +1470,26 @@ components:
           $ref: '#/components/schemas/NetworkIdentifier'
         offset:
           description: |
+            offset is the offset into the event stream to sync events from. If this
+            is left empty, we stream the limit from tip. If this is set to 0,
+            we start from the beginning.
           type: integer
           format: int64
           minimum: 0
           example: 5
         limit:
           description: |
+            limit is the maximum number of events to fetch in one call. The implementation
+            may return up to this limit but there is no guarantee it will return all limit
+            events.
           type: integer
           format: int64
           minimum: 0
           example: 5
     EventsBlocksResponse:
       description: |
+        EventsBlocksResponse contains an ordered collection of BlockEvents
+        and the largest available retrievable sequence.
       type: object
       required:
         - max_sequence
@@ -1488,6 +1497,7 @@ components:
       properties:
         max_sequence:
           description: |
+            max_sequence is the maximum available sequence number to fetch.
           type: integer
           format: int64
           minimum: 0
@@ -1495,6 +1505,10 @@ components:
         events:
           type: array
           description: |
+            events is an array of BlockEvents indicating the order to add
+            and remove blocks to maintain a consistent view of blockchain
+            state. Following this event stream prevents some lightweight
+            clients from running their own syncer.
           items:
             $ref: '#/components/schemas/BlockEvent'
 

--- a/api.yaml
+++ b/api.yaml
@@ -658,10 +658,10 @@ paths:
       summary: |
         [INDEXER] Get a range of BlockEvents
       description: |
-        `/events/blocks` allows the caller to query a stream
+        `/events/blocks` allows the caller to query a sequence
         of BlockEvents indicating which blocks were added and
-        removed from storage to reach the indexer's current state.
-        Streaming BlockEvents allows lightweight clients to update
+        removed from storage to reach the current state.
+        Following BlockEvents allows lightweight clients to update
         their state without needing to implement their own syncing
         logic (like finding the common parent in a reorg).
 
@@ -1489,7 +1489,8 @@ components:
     EventsBlocksRequest:
       description: |
         EventsBlocksRequest is utilized to fetch a sequence of BlockEvents
-        indicating which blocks were added and removed during syncing.
+        indicating which blocks were added and removed from storage to
+        reach the current state.
       type: object
       required:
         - network_identifier
@@ -1499,8 +1500,8 @@ components:
         offset:
           description: |
             offset is the offset into the event stream to sync events from. If this
-            is left empty, we stream the limit from tip. If this is set to 0,
-            we start from the beginning.
+            field is not populated, we return the limit events backwards from tip.
+            If this is set to 0, we start from the beginning.
           type: integer
           format: int64
           minimum: 0

--- a/api.yaml
+++ b/api.yaml
@@ -653,6 +653,58 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /events/blocks:
+    post:
+      summary: blah blah
+      description: |
+      operationId: eventsBlocks
+      tags:
+        - Events
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventsBlocksRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventsBlocksResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /search/transactions:
+    post:
+      summary: blah blah
+      description: |
+      operationId: searchTransactions
+      tags:
+        - Search
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchTransactionsRequest'
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchTransactionsResponse'
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     # Identifiers

--- a/api.yaml
+++ b/api.yaml
@@ -655,8 +655,19 @@ paths:
                 $ref: '#/components/schemas/Error'
   /events/blocks:
     post:
-      summary: blah blah
+      summary: [INDEXER] Get a range of BlockEvents
       description: |
+        `/events/blocks` allows the caller to query a stream
+        of BlockEvents indicating which blocks were added and
+        removed from storage to reach the indexer's current state.
+        Streaming BlockEvents allows lightweight clients to update
+        their state without needing to implement their own syncing
+        logic (like finding the common parent in a reorg).
+
+        `/events/blocks` is considered an "indexer" endpoint
+        and Rosetta implementations are not required to complete it
+        to adhere to the Rosetta spec. However, any Rosetta "indexer"
+        MUST support this endpoint.
       operationId: eventsBlocks
       tags:
         - Events
@@ -681,8 +692,18 @@ paths:
                 $ref: '#/components/schemas/Error'
   /search/transactions:
     post:
-      summary: blah blah
+      summary: [INDEXER] Search for Transactions
       description: |
+        `/search/transactions` allows the caller to search for
+        transactions that meet certain conditions. Some conditions
+        include matching a transaction hash, containing an
+        operation with a certain status, or containing an operation
+        that affects a certain account.
+
+        `/search/transactions` is considered an "indexer" endpoint
+        and Rosetta implementations are not required to complete it
+        to adhere to the Rosetta spec. However, any Rosetta "indexer"
+        MUST support this endpoint.
       operationId: searchTransactions
       tags:
         - Search
@@ -1461,7 +1482,8 @@ components:
             true here or they could cause issues for the caller.
     EventsBlocksRequest:
       description: |
-        EventsBlocksRequest 
+        EventsBlocksRequest is utilized to fetch a sequence of BlockEvents
+        indicating which blocks were added and removed during syncing.
       type: object
       required:
         - network_identifier
@@ -1480,8 +1502,7 @@ components:
         limit:
           description: |
             limit is the maximum number of events to fetch in one call. The implementation
-            may return up to this limit but there is no guarantee it will return all limit
-            events.
+            may return <= limit events.
           type: integer
           format: int64
           minimum: 0
@@ -1489,7 +1510,7 @@ components:
     EventsBlocksResponse:
       description: |
         EventsBlocksResponse contains an ordered collection of BlockEvents
-        and the largest available retrievable sequence.
+        and the max retrievable sequence.
       type: object
       required:
         - max_sequence
@@ -1506,9 +1527,9 @@ components:
           type: array
           description: |
             events is an array of BlockEvents indicating the order to add
-            and remove blocks to maintain a consistent view of blockchain
-            state. Following this event stream prevents some lightweight
-            clients from running their own syncer.
+            and remove blocks to maintain a canonical view of blockchain
+            state. Lightweight clients can use this event stream to update
+            state without implementing their own block syncing logic.
           items:
             $ref: '#/components/schemas/BlockEvent'
 

--- a/api.yaml
+++ b/api.yaml
@@ -1539,7 +1539,7 @@ components:
     SearchTransactionsRequest:
       description: |
         SearchTransactionsRequest is used to search for transactions
-        matching a set of provided conditions.
+        matching a set of provided conditions in canonical blocks.
       type: object
       required:
         - network_identifier
@@ -1554,6 +1554,20 @@ components:
             max_block is the largest block index to consider when searching
             for transactions. If this field is not populated, the current
             block is considered the max_block.
+
+            If you do not specify a max_block, it is possible a newly synced
+            block will interfere with paginated transaction queries (as the offset
+            could become invalid with newly added rows).
+          type: integer
+          format: int64
+          minimum: 0
+          example: 5
+        offset:
+          description: |
+            offset is the offset into the query result to start returning transactions.
+
+            If any search conditions are changed, the query offset will change and you
+            must restart your search iteration.
           type: integer
           format: int64
           minimum: 0
@@ -1562,10 +1576,6 @@ components:
           description: |
             limit is the maximum number of transactions to return in one call. The implementation
             may return <= limit transactions.
-
-            If returning all transactions in a block would surpass the specified
-            limit (so that only some transactions in a block would be returned),
-            no transactions from that block are returned.
           type: integer
           format: int64
           minimum: 0
@@ -1607,10 +1617,11 @@ components:
       required:
         - transactions
       properties:
-        next_max_block:
+        next_offset:
           description: |
-            next_max_block is the next max_block to use when querying transactions.
-            If there are no more transactions to fetch, this field is not returned.
+            next_offset is the next offset to use when paginating through
+            transaction results. If this field is not populated, there are
+            no more transactions to query.
           type: integer
           format: int64
           minimum: 0

--- a/api.yaml
+++ b/api.yaml
@@ -655,7 +655,8 @@ paths:
                 $ref: '#/components/schemas/Error'
   /events/blocks:
     post:
-      summary: [INDEXER] Get a range of BlockEvents
+      summary: |
+        [INDEXER] Get a range of BlockEvents
       description: |
         `/events/blocks` allows the caller to query a stream
         of BlockEvents indicating which blocks were added and
@@ -692,7 +693,8 @@ paths:
                 $ref: '#/components/schemas/Error'
   /search/transactions:
     post:
-      summary: [INDEXER] Search for Transactions
+      summary: |
+        [INDEXER] Search for Transactions
       description: |
         `/search/transactions` allows the caller to search for
         transactions that meet certain conditions. Some conditions
@@ -1637,7 +1639,7 @@ components:
             may not contain all matching transactions. It is up to the caller to
             paginate these transactions using the max_block field.
           items:
-            $ref: 'BlockTransaction.yaml'
+            $ref: '#/components/schemas/BlockTransaction'
 
     # Miscellaneous
     Error:

--- a/models/BlockEvent.yaml
+++ b/models/BlockEvent.yaml
@@ -13,12 +13,24 @@
 # limitations under the License.
 
 description: |
+  BlockEvent represents the addition or removal of a BlockIdentifier
+  from the stored state of an indexer. Streaming BlockEvents allows
+  lightweight clients to update their own state without needing to
+  implement their own syncing logic.
 type: object
 required:
   - sequence
   - block_identifier 
   - type 
 properties:
+  sequence:
+    description: |
+      sequence is the unique identifier of a BlockEvent
+      within the context of a NetworkIdentifier.
+    type: integer
+    format: int64
+    minimum: 0
+    example: 5
   block_identifier:
     $ref: 'BlockIdentifier.yaml'
   type:

--- a/models/BlockEvent.yaml
+++ b/models/BlockEvent.yaml
@@ -14,9 +14,8 @@
 
 description: |
   BlockEvent represents the addition or removal of a BlockIdentifier
-  from the stored state of an indexer. Streaming BlockEvents allows
-  lightweight clients to update their own state without needing to
-  implement their own syncing logic.
+  from storage. Streaming BlockEvents allows lightweight clients to
+  update their own state without needing to implement their own syncing logic.
 type: object
 required:
   - sequence

--- a/models/BlockEvent.yaml
+++ b/models/BlockEvent.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+type: object
+required:
+  - sequence
+  - block_identifier 
+  - type 
+properties:
+  block_identifier:
+    $ref: 'BlockIdentifier.yaml'
+  type:
+    $ref: 'BlockEventType.yaml'

--- a/models/BlockEventType.yaml
+++ b/models/BlockEventType.yaml
@@ -1,0 +1,19 @@
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+type: string
+enum:
+  - block_added
+  - block_removed

--- a/models/BlockEventType.yaml
+++ b/models/BlockEventType.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 description: |
+  BlockEventType determines if a BlockEvent represents the
+  addition or removal of a block.
 type: string
 enum:
   - block_added

--- a/models/BlockTransaction.yaml
+++ b/models/BlockTransaction.yaml
@@ -1,0 +1,26 @@
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  BlockTransaction contains a populated Transaction
+  and the BlockIdentifier that contains it.
+type: object
+required:
+  - block_identifier 
+  - transaction 
+properties:
+  block_identifier:
+    $ref: 'BlockIdentifier.yaml'
+  transaction:
+    $ref: 'Transaction.yaml'

--- a/models/Operator.yaml
+++ b/models/Operator.yaml
@@ -1,0 +1,21 @@
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: |
+  Operator is used by query-related endpoints
+  to determine how to apply conditions.
+type: string
+enum:
+  - or 
+  - and 


### PR DESCRIPTION
This PR adds support for standard "indexer" endpoints (optional for any Rosetta implementation to complete). Anyone can write a compliant Rosetta Indexer by supporting these new endpoints and clients can access any of these indexers without a separate SDK.

### Changes
- [x] `/events/blocks` endpoint
- [x] `/search/transactions` endpoint
- [x] Update README