### PR TITLE
`SearchTransactionsRequest.Operator` Optional

### DIFF
--- a/api.json
+++ b/api.json
@@ -1533,7 +1533,7 @@
         ]
       },
      "Operator": {
-       "description":"Operator is used by query-related endpoints to determine how to apply conditions.",
+       "description":"Operator is used by query-related endpoints to determine how to apply conditions. If this field is not populated, the default `and` value will be used.",
        "type":"string",
        "enum": [
          "or",
@@ -2278,8 +2278,7 @@
        "description":"SearchTransactionsRequest is used to search for transactions matching a set of provided conditions in canonical blocks.",
        "type":"object",
        "required": [
-         "network_identifier",
-         "operator"
+         "network_identifier"
         ],
        "properties": {
          "network_identifier": {

--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.7",
+   "version":"1.4.8",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {

--- a/api.yaml
+++ b/api.yaml
@@ -1546,7 +1546,6 @@ components:
       type: object
       required:
         - network_identifier
-        - operator
       properties:
         network_identifier:
           $ref: '#/components/schemas/NetworkIdentifier'

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.7
+  version: 1.4.8
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.

--- a/models/Operator.yaml
+++ b/models/Operator.yaml
@@ -15,6 +15,9 @@
 description: |
   Operator is used by query-related endpoints
   to determine how to apply conditions.
+
+  If this field is not populated, the default
+  `and` value will be used.
 type: string
 enum:
   - or 


### PR DESCRIPTION
This PR makes `operator` an optional field on `SearchTransactionsRequest`. In short, this change was made because supplying an `operator` when there is only 1 condition provided can be quite confusing.

### Changes
- [x] update `api.yaml`
- [x] generate new spec
- [x] update spec version (-> `1.4.8`)