### PR TITLE
[indexer] Add `total_count` field

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.8",
+   "version":"1.4.9",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {
@@ -2345,22 +2345,30 @@
        "description":"SearchTransactionsResponse contains an ordered collection of BlockTransactions that match the query in SearchTransactionsRequest. These BlockTransactions are sorted from most recent block to oldest block.",
        "type":"object",
        "required": [
-         "transactions"
+         "transactions",
+         "total_count"
         ],
        "properties": {
-         "next_offset": {
-           "description":"next_offset is the next offset to use when paginating through transaction results. If this field is not populated, there are no more transactions to query.",
-           "type":"integer",
-           "format":"int64",
-           "minimum": 0,
-           "example": 5
-          },
          "transactions": {
            "type":"array",
            "description":"transactions is an array of BlockTransactions sorted by most recent BlockIdentifier (meaning that transactions in recent blocks appear first). If there are many transactions for a particular search, transactions may not contain all matching transactions. It is up to the caller to paginate these transactions using the max_block field.",
            "items": {
              "$ref":"#/components/schemas/BlockTransaction"
             }
+          },
+         "total_count": {
+           "description":"total_count is the number of results for a given search. Callers typically use this value to concurrently fetch results by offset or to display a virtual page number associated with results.",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
+          },
+         "next_offset": {
+           "description":"next_offset is the next offset to use when paginating through transaction results. If this field is not populated, there are no more transactions to query.",
+           "type":"integer",
+           "format":"int64",
+           "minimum": 0,
+           "example": 5
           }
         }
       },

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.8
+  version: 1.4.9
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.
@@ -1620,16 +1620,8 @@ components:
       type: object
       required:
         - transactions
+        - total_count
       properties:
-        next_offset:
-          description: |
-            next_offset is the next offset to use when paginating through
-            transaction results. If this field is not populated, there are
-            no more transactions to query.
-          type: integer
-          format: int64
-          minimum: 0
-          example: 5
         transactions:
           type: array
           description: |
@@ -1642,6 +1634,24 @@ components:
             paginate these transactions using the max_block field.
           items:
             $ref: '#/components/schemas/BlockTransaction'
+        total_count:
+          description: |
+            total_count is the number of results for a given search. Callers
+            typically use this value to concurrently fetch results by offset
+            or to display a virtual page number associated with results.
+          type: integer
+          format: int64
+          minimum: 0
+          example: 5
+        next_offset:
+          description: |
+            next_offset is the next offset to use when paginating through
+            transaction results. If this field is not populated, there are
+            no more transactions to query.
+          type: integer
+          format: int64
+          minimum: 0
+          example: 5
 
     # Miscellaneous
     Error:


### PR DESCRIPTION
Closes: #69 

This PR adds a new `total_count` field to the `SearchTransactionResponse`. This enables callers to concurrently fetch search results.

### Changes
- [x] Add `total_count` field to `SearchTransactionResponse`
- [x] Run `make gen`
- [x] Update specification version to `v1.4.9`