### PR TITLE
add modeling for related transactions

### DIFF
--- a/api.json
+++ b/api.json
@@ -1564,7 +1564,7 @@
         }
       },
      "RelatedTransaction": {
-       "description":"The related_transaction allows implementations to link together multiple transactions.",
+       "description":"The related_transaction allows implementations to link together multiple transactions. An unpopulated network identifier indicates that the related transaction is on the same network.",
        "type":"object",
        "required": [
          "transaction_identifier",
@@ -1583,7 +1583,7 @@
         }
       },
      "Direction": {
-       "description":"Direction of the relation (i.e. cross-shard/cross-network sends may reference \"back\" to an earlier transaction and async execution may reference \"forward\")",
+       "description":"Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference \"back\" to an earlier transaction and async execution may reference \"forward\"). Can be used to indicate if a transaction relation is from child to parent or the reverse.",
        "type":"string",
        "enum": [
          "forward",

--- a/api.json
+++ b/api.json
@@ -1571,21 +1571,24 @@
          "direction"
         ],
        "properties": {
-         "transaction_identifier": {
-           "$ref":"#/components/schemas/TransactionIdentifier"
-          },
          "network_identifier": {
            "$ref":"#/components/schemas/NetworkIdentifier"
           },
+         "transaction_identifier": {
+           "$ref":"#/components/schemas/TransactionIdentifier"
+          },
          "direction": {
-           "description":"Direction of the relation (i.e. cross-shard/cross-network sends may reference \"back\" to an earlier transaction and async execution may reference \"forward\")",
-           "type":"string",
-           "enum": [
-             "forward",
-             "backward"
-            ]
+           "$ref":"#/components/schemas/Direction"
           }
         }
+      },
+     "Direction": {
+       "description":"Direction of the relation (i.e. cross-shard/cross-network sends may reference \"back\" to an earlier transaction and async execution may reference \"forward\")",
+       "type":"string",
+       "enum": [
+         "forward",
+         "backward"
+        ]
       },
      "AccountBalanceRequest": {
        "description":"An AccountBalanceRequest is utilized to make a balance request on the /account/balance endpoint. If the block_identifier is populated, a historical balance query should be performed.",

--- a/api.json
+++ b/api.json
@@ -1056,6 +1056,12 @@
              "$ref":"#/components/schemas/Operation"
             }
           },
+         "related_transactions": {
+           "type":"array",
+           "items": {
+             "$ref":"#/components/schemas/RelatedTransaction"
+            }
+          },
          "metadata": {
            "description":"Transactions that are related to other transactions (like a cross-shard transaction) should include the tranaction_identifier of these transactions in the metadata.",
            "type":"object",
@@ -1554,6 +1560,30 @@
           },
          "transaction": {
            "$ref":"#/components/schemas/Transaction"
+          }
+        }
+      },
+     "RelatedTransaction": {
+       "description":"The related_transaction allows implementations to link together multiple transactions.",
+       "type":"object",
+       "required": [
+         "transaction_identifier",
+         "direction"
+        ],
+       "properties": {
+         "transaction_identifier": {
+           "$ref":"#/components/schemas/TransactionIdentifier"
+          },
+         "network_identifier": {
+           "$ref":"#/components/schemas/NetworkIdentifier"
+          },
+         "direction": {
+           "description":"Direction of the relation (i.e. cross-shard/cross-network sends may reference \"back\" to an earlier transaction and async execution may reference \"forward\")",
+           "type":"string",
+           "enum": [
+             "forward",
+             "backward"
+            ]
           }
         }
       },

--- a/api.yaml
+++ b/api.yaml
@@ -801,6 +801,8 @@ components:
       $ref: 'models/Operator.yaml'
     BlockTransaction:
       $ref: 'models/BlockTransaction.yaml'
+    RelatedTransaction:
+      $ref: 'models/RelatedTransaction.yaml'
 
     # Request/Responses
     AccountBalanceRequest:

--- a/api.yaml
+++ b/api.yaml
@@ -803,6 +803,8 @@ components:
       $ref: 'models/BlockTransaction.yaml'
     RelatedTransaction:
       $ref: 'models/RelatedTransaction.yaml'
+    Direction:
+      $ref: 'models/Direction.yaml'
 
     # Request/Responses
     AccountBalanceRequest:

--- a/models/Direction.yaml
+++ b/models/Direction.yaml
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 description: |
-  Direction of the relation (i.e. cross-shard/cross-network sends may reference "back" to an earlier transaction
-  and async execution may reference "forward")
+  Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may
+  reference "back" to an earlier transaction and async execution may reference "forward"). Can be used to indicate if
+  a transaction relation is from child to parent or the reverse.
 type: string
 enum:
   - forward

--- a/models/Direction.yaml
+++ b/models/Direction.yaml
@@ -11,17 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 description: |
-  The related_transaction allows implementations to link together multiple transactions.
-type: object
-required:
-  - transaction_identifier
-  - direction
-properties:
-  network_identifier:
-    $ref: 'NetworkIdentifier.yaml'
-  transaction_identifier:
-    $ref: 'TransactionIdentifier.yaml'
-  direction:
-    $ref: 'Direction.yaml'
+  Direction of the relation (i.e. cross-shard/cross-network sends may reference "back" to an earlier transaction
+  and async execution may reference "forward")
+type: string
+enum:
+  - forward
+  - backward

--- a/models/RelatedTransaction.yaml
+++ b/models/RelatedTransaction.yaml
@@ -14,6 +14,7 @@
 
 description: |
   The related_transaction allows implementations to link together multiple transactions.
+  An unpopulated network identifier indicates that the related transaction is on the same network.
 type: object
 required:
   - transaction_identifier

--- a/models/RelatedTransaction.yaml
+++ b/models/RelatedTransaction.yaml
@@ -13,28 +13,21 @@
 # limitations under the License.
 
 description: |
-  Transactions contain an array of Operations
-  that are attributable to the same TransactionIdentifier.
+  The related_transaction allows implementations to link together multiple transactions.
 type: object
 required:
   - transaction_identifier
-  - operations
+  - direction
 properties:
   transaction_identifier:
     $ref: 'TransactionIdentifier.yaml'
-  operations:
-    type: array
-    items:
-      $ref: 'Operation.yaml'
-  related_transactions:
-    type: array
-    items:
-      $ref: 'RelatedTransaction.yaml'
-  metadata:
+  network_identifier:
+    $ref: 'NetworkIdentifier.yaml'
+  direction:
     description: |
-      Transactions that are related to other transactions (like a cross-shard transaction) should include
-      the tranaction_identifier of these transactions in the metadata.
-    type: object
-    example:
-      size: 12378
-      lockTime: 1582272577
+      Direction of the relation (i.e. cross-shard/cross-network sends may reference "back" to an earlier transaction
+      and async execution may reference "forward")
+    type: string
+    enum:
+      - forward
+      - backward


### PR DESCRIPTION
Fixes # .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Adds support for the planned related transaction feature that will allow linking of multiple transactions within rosetta.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->-
Transactions will now feature an optional related_transactions array of RelatedTransaction objects. Related Transaction objects feature a network_identifier (optional), transaction_identifier, and direction (forward or backward). This was done to provide support for multiple relations of different directions across multiple networks if necessary.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
