### PR TITLE
Add Support for Related Transactions

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.9",
+   "version":"1.4.10",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {

--- a/api.json
+++ b/api.json
@@ -1056,6 +1056,12 @@
              "$ref":"#/components/schemas/Operation"
             }
           },
+         "related_transactions": {
+           "type":"array",
+           "items": {
+             "$ref":"#/components/schemas/RelatedTransaction"
+            }
+          },
          "metadata": {
            "description":"Transactions that are related to other transactions (like a cross-shard transaction) should include the tranaction_identifier of these transactions in the metadata.",
            "type":"object",
@@ -1556,6 +1562,33 @@
            "$ref":"#/components/schemas/Transaction"
           }
         }
+      },
+     "RelatedTransaction": {
+       "description":"The related_transaction allows implementations to link together multiple transactions. An unpopulated network identifier indicates that the related transaction is on the same network.",
+       "type":"object",
+       "required": [
+         "transaction_identifier",
+         "direction"
+        ],
+       "properties": {
+         "network_identifier": {
+           "$ref":"#/components/schemas/NetworkIdentifier"
+          },
+         "transaction_identifier": {
+           "$ref":"#/components/schemas/TransactionIdentifier"
+          },
+         "direction": {
+           "$ref":"#/components/schemas/Direction"
+          }
+        }
+      },
+     "Direction": {
+       "description":"Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference \"back\" to an earlier transaction and async execution may reference \"forward\"). Can be used to indicate if a transaction relation is from child to parent or the reverse.",
+       "type":"string",
+       "enum": [
+         "forward",
+         "backward"
+        ]
       },
      "AccountBalanceRequest": {
        "description":"An AccountBalanceRequest is utilized to make a balance request on the /account/balance endpoint. If the block_identifier is populated, a historical balance query should be performed.",

--- a/api.json
+++ b/api.json
@@ -1583,7 +1583,7 @@
         }
       },
      "Direction": {
-       "description":"Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `back` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse.",
+       "description":"Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse.",
        "type":"string",
        "enum": [
          "forward",

--- a/api.json
+++ b/api.json
@@ -1583,7 +1583,7 @@
         }
       },
      "Direction": {
-       "description":"Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference \"back\" to an earlier transaction and async execution may reference \"forward\"). Can be used to indicate if a transaction relation is from child to parent or the reverse.",
+       "description":"Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may reference `back` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if a transaction relation is from child to parent or the reverse.",
        "type":"string",
        "enum": [
          "forward",

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.9
+  version: 1.4.10
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.

--- a/api.yaml
+++ b/api.yaml
@@ -801,6 +801,10 @@ components:
       $ref: 'models/Operator.yaml'
     BlockTransaction:
       $ref: 'models/BlockTransaction.yaml'
+    RelatedTransaction:
+      $ref: 'models/RelatedTransaction.yaml'
+    Direction:
+      $ref: 'models/Direction.yaml'
 
     # Request/Responses
     AccountBalanceRequest:

--- a/models/Direction.yaml
+++ b/models/Direction.yaml
@@ -1,0 +1,21 @@
+# Copyright 2020 Coinbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: |
+  Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may
+  reference "back" to an earlier transaction and async execution may reference "forward"). Can be used to indicate if
+  a transaction relation is from child to parent or the reverse.
+type: string
+enum:
+  - forward
+  - backward

--- a/models/Direction.yaml
+++ b/models/Direction.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 description: |
   Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may
-  reference `back` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if
+  reference `backward` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if
   a transaction relation is from child to parent or the reverse.
 type: string
 enum:

--- a/models/Direction.yaml
+++ b/models/Direction.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 description: |
   Used by RelatedTransaction to indicate the direction of the relation (i.e. cross-shard/cross-network sends may
-  reference "back" to an earlier transaction and async execution may reference "forward"). Can be used to indicate if
+  reference `back` to an earlier transaction and async execution may reference `forward`). Can be used to indicate if
   a transaction relation is from child to parent or the reverse.
 type: string
 enum:

--- a/models/RelatedTransaction.yaml
+++ b/models/RelatedTransaction.yaml
@@ -13,28 +13,16 @@
 # limitations under the License.
 
 description: |
-  Transactions contain an array of Operations
-  that are attributable to the same TransactionIdentifier.
+  The related_transaction allows implementations to link together multiple transactions.
+  An unpopulated network identifier indicates that the related transaction is on the same network.
 type: object
 required:
   - transaction_identifier
-  - operations
+  - direction
 properties:
+  network_identifier:
+    $ref: 'NetworkIdentifier.yaml'
   transaction_identifier:
     $ref: 'TransactionIdentifier.yaml'
-  operations:
-    type: array
-    items:
-      $ref: 'Operation.yaml'
-  related_transactions:
-    type: array
-    items:
-      $ref: 'RelatedTransaction.yaml'
-  metadata:
-    description: |
-      Transactions that are related to other transactions (like a cross-shard transaction) should include
-      the tranaction_identifier of these transactions in the metadata.
-    type: object
-    example:
-      size: 12378
-      lockTime: 1582272577
+  direction:
+    $ref: 'Direction.yaml'


### PR DESCRIPTION
### Motivation
Adds support for the planned related transaction feature that will allow linking of multiple transactions within rosetta.

### Solution
Transactions will now feature an optional related_transactions array of RelatedTransaction objects. Related Transaction objects feature a network_identifier (optional), transaction_identifier, and direction (forward or backward). This was done to provide support for multiple relations of different directions across multiple networks if necessary.

### Changes
- [x] Update version to `1.4.10`
- [x] Add Related Transaction model
- [x] Add Direction enum
- [x] Update Transaction model with Related Transactions field 

### Open questions
N/A
