### PR TITLE
[PROTO-903] Add description for hex-bytes in SigningPayload

### DIFF
--- a/api.json
+++ b/api.json
@@ -1385,7 +1385,8 @@
            "$ref":"#/components/schemas/AccountIdentifier"
           },
          "hex_bytes": {
-           "type":"string"
+           "type":"string",
+           "description":"Hex-encoded string of the payload bytes."
           },
          "signature_type": {
            "$ref":"#/components/schemas/SignatureType"

--- a/models/SigningPayload.yaml
+++ b/models/SigningPayload.yaml
@@ -32,5 +32,7 @@ properties:
     $ref: 'AccountIdentifier.yaml'
   hex_bytes:
     type: string
+    description: |
+      Hex-encoded string of the payload bytes.
   signature_type:
     $ref: "SignatureType.yaml"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Description for hex-bytes was missing in the SigningPayload doc.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
