### PR TITLE
Add hash case sensitivity to the spec

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.10",
+   "version":"1.4.11",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {
@@ -910,7 +910,8 @@
           },
          "hash": {
            "type":"string",
-           "example":"0x1f2cc6c5027d2f201a5453ad1119574d2aed23a392654742ac3c78783c071f85"
+           "example":"0x1f2cc6c5027d2f201a5453ad1119574d2aed23a392654742ac3c78783c071f85",
+           "description":"This should be normalized according to the case specified in the block_hash_case network options."
           }
         }
       },
@@ -937,7 +938,7 @@
         ],
        "properties": {
          "hash": {
-           "description":"Any transactions that are attributable only to a block (ex: a block event) should use the hash of the block as the identifier.",
+           "description":"Any transactions that are attributable only to a block (ex: a block event) should use the hash of the block as the identifier.  This should be normalized according to the case specified in the transaction_hash_case in network options.",
            "type":"string",
            "example":"0x2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f"
           }
@@ -1311,6 +1312,22 @@
          "mempool_coins": {
            "type":"boolean",
            "description":"Any Rosetta implementation that can update an AccountIdentifier's unspent coins based on the contents of the mempool should populate this field as true. If false, requests to `/account/coins` that set `include_mempool` as true will be automatically rejected."
+          },
+         "block_hash_case": {
+           "description":"This specifies the normalized case for block hash in the BlockIdentifier. If not specified, it's assumed to be case sensitive.",
+           "type":"string",
+           "nullable": true,
+           "enum": [
+             "upper_case",
+             "lower_case",
+             "case_sensitive",
+              null
+            ],
+           "default":"case_sensitive"
+          },
+         "transaction_hash_case": {
+           "$ref":"#/components/schemas/Allow/properties/block_hash_case",
+           "description":"This specifies the normalized case for transaction hash in the TransactionIdentifier. If not specified, it's assumed to be case sensitive."
           }
         }
       },

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.10
+  version: 1.4.11
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.

--- a/models/Allow.yaml
+++ b/models/Allow.yaml
@@ -103,3 +103,13 @@ properties:
       coins based on the contents of the mempool should populate this field
       as true. If false, requests to `/account/coins` that set `include_mempool`
       as true will be automatically rejected.
+  block_hash_case:
+    $ref: 'Case.yaml'
+    description: |
+      This specifies the normalized case for block hash in the BlockIdentifier.
+      If not specified, it's assumed to be case sensitive.
+  transaction_hash_case:
+    $ref: 'Case.yaml'
+    description: |
+      This specifies the normalized case for transaction hash in the TransactionIdentifier.
+      If not specified, it's assumed to be case sensitive.

--- a/models/Case.yaml
+++ b/models/Case.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Coinbase, Inc.
+# Copyright 2021 Coinbase, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,21 +13,13 @@
 # limitations under the License.
 
 description: |
-  The block_identifier uniquely identifies a block in a particular network.
-type: object
-required:
-  - index
-  - hash
-properties:
-  index:
-    description: |
-      This is also known as the block height.
-    type: integer
-    format: int64
-    example: 1123941
-  hash:
-    type: string
-    example: "0x1f2cc6c5027d2f201a5453ad1119574d2aed23a392654742ac3c78783c071f85"
-    description: |
-      This should be normalized according to the case specified in the block_hash_case
-      network options.
+  Case specifies the expected case for strings and hashes.
+type: string
+nullable: true
+enum:
+  - upper_case
+  - lower_case
+  - case_sensitive
+  - null
+default: case_sensitive
+

--- a/models/TransactionIdentifier.yaml
+++ b/models/TransactionIdentifier.yaml
@@ -22,6 +22,7 @@ properties:
   hash:
     description: |
       Any transactions that are attributable only to a block (ex: a block event)
-      should use the hash of the block as the identifier.
+      should use the hash of the block as the identifier.  This should be normalized according to
+      the case specified in the transaction_hash_case in network options.
     type: string
     example: "0x2f23fd8cca835af21f3ac375bac601f97ead75f2e79143bdf71fe2c4be043e8f"


### PR DESCRIPTION
Signed-off-by: Henry Yang <yhenry@gmail.com>

Fixes # .

### Motivation
Add network option to clarify the case sensitivity for block hash and transaction hash.

### Solution
Add new block_hash_case and transaction_hash_case
Update the description in the BlockIdentifier and TransactionIdentifier

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
