### PR TITLE
Add bls12-381 curve to Rosetta spec

### DIFF
--- a/models/CurveType.yaml
+++ b/models/CurveType.yaml
@@ -20,6 +20,7 @@ description: |
   * edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf)
   * tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes) (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys)
   * pallas: `x (255 bits) || y-parity-bit (1-bit) - 32 bytes` (https://github.com/zcash/pasta)
+  * bls12381: `G1 Point in compressed Zcash format (48 bytes)` (https://datatracker.ietf.org/doc/draft-irtf-cfrg-bls-signature/04/)
 
 type: string
 enum:
@@ -28,3 +29,4 @@ enum:
   - edwards25519
   - tweedle
   - pallas
+  - bls12381

--- a/models/SignatureType.yaml
+++ b/models/SignatureType.yaml
@@ -20,6 +20,8 @@ description: |
   * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
   * schnorr_1: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first.)
   * schnorr_poseidon: `r (32-bytes) || s (32-bytes)` where s = Hash(1st pk || 2nd pk || r) - `64 bytes`  (schnorr signature w/ Poseidon hash function implemented by O(1) Labs where both `r` and `s` are scalars encoded as `32-bytes` values, least significant byte first. https://github.com/CodaProtocol/signer-reference/blob/master/schnorr.ml )
+  * bls12381_basic_mpl: G2 Point in compressed Zcash format (96 bytes) - Basic Scheme
+  * bls12381_basic_mpl: G2 Point in compressed Zcash format (96 bytes) - Aug Scheme
 type: string
 enum:
   - ecdsa
@@ -27,3 +29,5 @@ enum:
   - ed25519
   - schnorr_1
   - schnorr_poseidon
+  - bls12381_basic_mpl
+  - bls12381_aug_mpl


### PR DESCRIPTION
Fixes # .

### Motivation

Adds BLS12-381 curve to spec with support for both Basic and Aug signature schemes.

### Solution

### Open questions
