### PR TITLE
Remove `peers` as a required field in NetworkStatusResponse

### DIFF
--- a/api.json
+++ b/api.json
@@ -1880,8 +1880,7 @@
        "required": [
          "current_block_identifier",
          "current_block_timestamp",
-         "genesis_block_identifier",
-         "peers"
+         "genesis_block_identifier"
         ],
        "properties": {
          "current_block_identifier": {

--- a/api.yaml
+++ b/api.yaml
@@ -1084,7 +1084,6 @@ components:
         - current_block_identifier
         - current_block_timestamp
         - genesis_block_identifier
-        - peers
       properties:
         current_block_identifier:
           $ref: '#/components/schemas/BlockIdentifier'


### PR DESCRIPTION
### Motivation
Some chains don't have `peers` in `/network/status` response and the system allows for it to be empty. However, it shows up as required. 

### Solution
Remove `peers` from the required fields for NetworkStatusResponse.

