### PR TITLE
(nit) Reverted api.json to previous commit

### DIFF
--- a/api.json
+++ b/api.json
@@ -1880,7 +1880,8 @@
        "required": [
          "current_block_identifier",
          "current_block_timestamp",
-         "genesis_block_identifier"
+         "genesis_block_identifier",
+         "peers"
         ],
        "properties": {
          "current_block_identifier": {


### PR DESCRIPTION
### Motivation
Needed to revert so that api.json can be auto-generated.