### PR TITLE
(chore) Update API version to 1.4.13

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.12",
+   "version":"1.4.13",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.12
+  version: 1.4.13
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.


### PR DESCRIPTION
### Motivation
Removed `peers` as a required field for NetworkStatusResponse.