### PR TITLE
[preprocess]remove max_fee and mulltiplier in preprocess request

### DIFF
--- a/api.json
+++ b/api.json
@@ -1996,7 +1996,7 @@
         }
       },
      "ConstructionPreprocessRequest": {
-       "description":"ConstructionPreprocessRequest is passed to the `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata it needs to request for construction. Metadata provided in this object should NEVER be a product of live data (i.e. the caller must follow some network-specific data fetching strategy outside of the Construction API to populate required Metadata). If live data is required for construction, it MUST be fetched in the call to `/construction/metadata`. The caller can provide a max fee they are willing to pay for a transaction. This is an array in the case fees must be paid in multiple currencies. The caller can also provide a suggested fee multiplier to indicate that the suggested fee should be scaled. This may be used to set higher fees for urgent transactions or to pay lower fees when there is less urgency. It is assumed that providing a very low multiplier (like 0.0001) will never lead to a transaction being created with a fee less than the minimum network fee (if applicable). In the case that the caller provides both a max fee and a suggested fee multiplier, the max fee will set an upper bound on the suggested fee (regardless of the multiplier provided).",
+       "description":"ConstructionPreprocessRequest is passed to the `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata it needs to request for construction. Metadata provided in this object should NEVER be a product of live data (i.e. the caller must follow some network-specific data fetching strategy outside of the Construction API to populate required Metadata). If live data is required for construction, it MUST be fetched in the call to `/construction/metadata`. In the case that the caller provides both a max fee and a suggested fee multiplier, the max fee will set an upper bound on the suggested fee (regardless of the multiplier provided).",
        "type":"object",
        "required": [
          "network_identifier",
@@ -2014,17 +2014,6 @@
           },
          "metadata": {
            "type":"object"
-          },
-         "max_fee": {
-           "type":"array",
-           "items": {
-             "$ref":"#/components/schemas/Amount"
-            }
-          },
-         "suggested_fee_multiplier": {
-           "type":"number",
-           "format":"double",
-           "minimum": 0
           }
         }
       },

--- a/api.json
+++ b/api.json
@@ -1996,7 +1996,7 @@
         }
       },
      "ConstructionPreprocessRequest": {
-       "description":"ConstructionPreprocessRequest is passed to the `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata it needs to request for construction. Metadata provided in this object should NEVER be a product of live data (i.e. the caller must follow some network-specific data fetching strategy outside of the Construction API to populate required Metadata). If live data is required for construction, it MUST be fetched in the call to `/construction/metadata`. In the case that the caller provides both a max fee and a suggested fee multiplier, the max fee will set an upper bound on the suggested fee (regardless of the multiplier provided).",
+       "description":"ConstructionPreprocessRequest is passed to the `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata it needs to request for construction. Metadata provided in this object should NEVER be a product of live data (i.e. the caller must follow some network-specific data fetching strategy outside of the Construction API to populate required Metadata). If live data is required for construction, it MUST be fetched in the call to `/construction/metadata`.",
        "type":"object",
        "required": [
          "network_identifier",

--- a/api.yaml
+++ b/api.yaml
@@ -1204,18 +1204,6 @@ components:
         required Metadata). If live data is required for construction, it MUST
         be fetched in the call to `/construction/metadata`.
 
-        The caller can provide a max fee they are willing
-        to pay for a transaction. This is an array in the case fees
-        must be paid in multiple currencies.
-
-        The caller can also provide a suggested fee multiplier
-        to indicate that the suggested fee should be scaled.
-        This may be used to set higher fees for urgent transactions
-        or to pay lower fees when there is less urgency. It is assumed
-        that providing a very low multiplier (like 0.0001) will
-        never lead to a transaction being created with a fee
-        less than the minimum network fee (if applicable).
-
         In the case that the caller provides both a max fee
         and a suggested fee multiplier, the max fee will set an
         upper bound on the suggested fee (regardless of the
@@ -1233,14 +1221,6 @@ components:
             $ref: '#/components/schemas/Operation'
         metadata:
           type: object
-        max_fee:
-          type: array
-          items:
-            $ref: '#/components/schemas/Amount'
-        suggested_fee_multiplier:
-          type: number
-          format: double
-          minimum: 0.0
     ConstructionPreprocessResponse:
       description: |
         ConstructionPreprocessResponse contains `options` that will

--- a/api.yaml
+++ b/api.yaml
@@ -1203,11 +1203,6 @@ components:
         data fetching strategy outside of the Construction API to populate
         required Metadata). If live data is required for construction, it MUST
         be fetched in the call to `/construction/metadata`.
-
-        In the case that the caller provides both a max fee
-        and a suggested fee multiplier, the max fee will set an
-        upper bound on the suggested fee (regardless of the
-        multiplier provided).
       type: object
       required:
         - network_identifier


### PR DESCRIPTION
Fixes # .

### Motivation
these two fields are conflict add complex in our internal services
and sometimes make the return dynamic fee unreliable 

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
