### PR TITLE
Add ml_dsa_65 (FIPS 204) to CurveType and SignatureType

### DIFF
--- a/api.json
+++ b/api.json
@@ -1464,7 +1464,7 @@
         }
       },
      "CurveType": {
-       "description":"CurveType is the type of cryptographic curve associated with a PublicKey. * secp256k1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * secp256k1_bip340: x-only - `32 bytes`  (implicitly even `Y` coord. Secp256k1 compressed keys may be repurposed by dropping the first byte. (https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Public_Key_Generation)) * secp256r1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf) * tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes) (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys) * pallas: `x (255 bits) || y-parity-bit (1-bit) - 32 bytes` (https://github.com/zcash/pasta)",
+       "description":"CurveType is the type of cryptographic curve associated with a PublicKey. Although this field is named `CurveType` for historical reasons, a value may also identify a post-quantum scheme that is not based on an elliptic curve; `ml_dsa_65` is the first such entry. * secp256k1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * secp256k1_bip340: x-only - `32 bytes`  (implicitly even `Y` coord. Secp256k1 compressed keys may be repurposed by dropping the first byte. (https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Public_Key_Generation)) * secp256r1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf) * tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes) (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys) * pallas: `x (255 bits) || y-parity-bit (1-bit) - 32 bytes` (https://github.com/zcash/pasta) * ml_dsa_65: FIPS 204 ML-DSA-65 post-quantum public key - `1952 bytes` (https://csrc.nist.gov/pubs/fips/204/final). Lattice-based, not an elliptic curve, but exposed through this field as the public-key-scheme discriminator.",
        "type":"string",
        "enum": [
          "secp256k1",
@@ -1472,7 +1472,8 @@
          "secp256r1",
          "edwards25519",
          "tweedle",
-         "pallas"
+         "pallas",
+         "ml_dsa_65"
         ]
       },
      "SigningPayload": {
@@ -1523,7 +1524,7 @@
         }
       },
      "SignatureType": {
-       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * schnorr_1: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first.) * schnorr_bip340: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (sig = (bytes(R) || bytes((k + ed) mod n) where `r` is the `X` coordinate of a point `R` whose `Y` coordinate is even, most significant bytes first.) * schnorr_poseidon: `r (32-bytes) || s (32-bytes)` where s = Hash(1st pk || 2nd pk || r) - `64 bytes`  (schnorr signature w/ Poseidon hash function implemented by O(1) Labs where both `r` and `s` are scalars encoded as `32-bytes` values, least significant byte first. https://github.com/CodaProtocol/signer-reference/blob/master/schnorr.ml )",
+       "description":"SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65 bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * schnorr_1: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first.) * schnorr_bip340: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (sig = (bytes(R) || bytes((k + ed) mod n) where `r` is the `X` coordinate of a point `R` whose `Y` coordinate is even, most significant bytes first.) * schnorr_poseidon: `r (32-bytes) || s (32-bytes)` where s = Hash(1st pk || 2nd pk || r) - `64 bytes`  (schnorr signature w/ Poseidon hash function implemented by O(1) Labs where both `r` and `s` are scalars encoded as `32-bytes` values, least significant byte first. https://github.com/CodaProtocol/signer-reference/blob/master/schnorr.ml ) * ml_dsa_65: FIPS 204 ML-DSA-65 post-quantum signature - `3309 bytes` (https://csrc.nist.gov/pubs/fips/204/final). Lattice-based, fixed-size byte string defined by FIPS 204 §3 (no internal field decomposition is exposed at this layer).",
        "type":"string",
        "enum": [
          "ecdsa",
@@ -1531,7 +1532,8 @@
          "ed25519",
          "schnorr_1",
          "schnorr_bip340",
-         "schnorr_poseidon"
+         "schnorr_poseidon",
+         "ml_dsa_65"
         ]
       },
      "CoinAction": {

--- a/models/CurveType.yaml
+++ b/models/CurveType.yaml
@@ -15,12 +15,17 @@
 description: |
   CurveType is the type of cryptographic curve associated with a PublicKey.
 
+  Although this field is named `CurveType` for historical reasons, a value
+  may also identify a post-quantum scheme that is not based on an elliptic
+  curve; `ml_dsa_65` is the first such entry.
+
   * secp256k1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3)
   * secp256k1_bip340: x-only - `32 bytes`  (implicitly even `Y` coord. Secp256k1 compressed keys may be repurposed by dropping the first byte. (https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Public_Key_Generation))
   * secp256r1: SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3)
   * edwards25519: `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf)
   * tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes) (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys)
   * pallas: `x (255 bits) || y-parity-bit (1-bit) - 32 bytes` (https://github.com/zcash/pasta)
+  * ml_dsa_65: FIPS 204 ML-DSA-65 post-quantum public key - `1952 bytes` (https://csrc.nist.gov/pubs/fips/204/final). Lattice-based, not an elliptic curve, but exposed through this field as the public-key-scheme discriminator.
 
 type: string
 enum:
@@ -30,3 +35,4 @@ enum:
   - edwards25519
   - tweedle
   - pallas
+  - ml_dsa_65

--- a/models/SignatureType.yaml
+++ b/models/SignatureType.yaml
@@ -21,6 +21,7 @@ description: |
   * schnorr_1: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (schnorr signature implemented by Zilliqa where both `r` and `s` are scalars encoded as `32-bytes` values, most significant byte first.)
   * schnorr_bip340: `r (32-bytes) || s (32-bytes)` - `64 bytes`  (sig = (bytes(R) || bytes((k + ed) mod n) where `r` is the `X` coordinate of a point `R` whose `Y` coordinate is even, most significant bytes first.)
   * schnorr_poseidon: `r (32-bytes) || s (32-bytes)` where s = Hash(1st pk || 2nd pk || r) - `64 bytes`  (schnorr signature w/ Poseidon hash function implemented by O(1) Labs where both `r` and `s` are scalars encoded as `32-bytes` values, least significant byte first. https://github.com/CodaProtocol/signer-reference/blob/master/schnorr.ml )
+  * ml_dsa_65: FIPS 204 ML-DSA-65 post-quantum signature - `3309 bytes` (https://csrc.nist.gov/pubs/fips/204/final). Lattice-based, fixed-size byte string defined by FIPS 204 §3 (no internal field decomposition is exposed at this layer).
 type: string
 enum:
   - ecdsa
@@ -29,3 +30,4 @@ enum:
   - schnorr_1
   - schnorr_bip340
   - schnorr_poseidon
+  - ml_dsa_65


### PR DESCRIPTION
Fixes # .

### Motivation

The NEAR Protocol is adding [FIPS 204 ML-DSA-65](https://csrc.nist.gov/pubs/fips/204/final) as a third transaction-signature scheme alongside `ed25519` and `secp256k1`. Its Mesh / Rosetta RPC implementation has no way to represent post-quantum public keys or signatures at the API boundary today, because the existing `CurveType` and `SignatureType` enums are closed and only cover classical elliptic-curve and Schnorr-style schemes.

Per a thread with the Mesh-Specifications maintainers ("We would gladly accept a PR ... with the new curve type and signature type."), this PR adds the minimum needed: a single new value `ml_dsa_65` in both enums. Other networks adopting post-quantum signatures (any of the FIPS 204 / FIPS 205 / FIPS 206 family) will need similar entries; landing the precedent for ML-DSA-65 first keeps that incremental.

### Solution

- `models/CurveType.yaml`: add `ml_dsa_65` to the enum and document it as a 1952-byte ML-DSA-65 public key with a pointer to FIPS 204. The field-level description also gains a note that, despite the historical name `CurveType`, the value may now identify a post-quantum scheme that is not based on an elliptic curve. The enum stays open-ended in spirit but remains a closed set in the spec; clients should reject unknown values exactly as they do today.
- `models/SignatureType.yaml`: add `ml_dsa_65` to the enum and document it as a 3309-byte ML-DSA-65 signature with a pointer to FIPS 204. The signature is a fixed-size opaque byte string per FIPS 204 §3; no internal field decomposition is exposed at this layer (matching how `ecdsa` / `ed25519` are exposed without internal structure).
- `api.json`: regenerated via `make gen` from the two YAML changes above; no hand-edits.

Backwards compatibility: pure enum addition. Clients that don't know `ml_dsa_65` should reject it the same way they reject any unknown enum value; clients that do know it gain a place to put PQ keys and sigs.

Local checks run:
- `make check-valid` (`swagger-cli validate api.yaml`) — pass.
- `make gen` then `git diff --exit-code` (i.e. `make check-gen`) — pass after committing the regenerated `api.json`.
- `make check-license` / `make spellcheck` / `make shellcheck` — not run locally (Go-based deps not installed on dev machine); CI is expected to catch any issues. No new files were created and no existing license headers or shell scripts were touched.
- `make salus` — not run locally (Docker-based).

### Open questions

- **Naming.** I chose `ml_dsa_65` (snake_case, all-lowercase, matching the `secp256k1_bip340` / `schnorr_poseidon` precedent). FIPS 204 calls the scheme "ML-DSA-65" in the spec; an alternative would be `mldsa65`. Happy to rename if you have a preference.
- **`CurveType` rename.** Adding a lattice scheme to a field called `CurveType` is a stretch. Renaming the field (or introducing a parallel `PublicKeyScheme`) would be cleaner but breaks every existing consumer. This PR leaves the field name alone and just notes the historical mismatch in the description — let me know if you'd rather take the breaking-change route instead.
- **Companion enums for FIPS 205 (SLH-DSA) / FIPS 206 (FN-DSA).** Not added here; happy to follow up if you want all three NIST-standardized PQ-DSA schemes covered in one PR rather than incrementally.